### PR TITLE
Using `returndatasize()` in assembly.

### DIFF
--- a/benchmark/Safe.MultiSend.spec.ts
+++ b/benchmark/Safe.MultiSend.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { BigNumberish } from "ethers";
+import { benchmark, Contracts } from "./utils/setup";
+import { buildMultiSendSafeTx } from "../src/utils/multisend";
+
+benchmark("MultiSend", async () => {
+    const [, , , , user5] = await ethers.getSigners();
+
+    return [
+        {
+            name: "multiple ERC20 transfers",
+            prepare: async (contracts: Contracts, target: string, nonce: BigNumberish) => {
+                const token = contracts.additions.token;
+                const multiSend = contracts.additions.multiSend;
+                await token.transfer(target, 1500);
+                const transfer = {
+                    to: await token.getAddress(),
+                    value: 0,
+                    data: token.interface.encodeFunctionData("transfer", [user5.address, 500]),
+                    operation: 0,
+                };
+                return buildMultiSendSafeTx(
+                    multiSend,
+                    [...Array(3)].map(() => transfer),
+                    nonce,
+                );
+            },
+            after: async (contracts: Contracts) => {
+                expect(await contracts.additions.token.balanceOf(user5.address)).to.eq(1500n);
+            },
+            fixture: async () => {
+                const multiSendFactory = await ethers.getContractFactory("MultiSend");
+                const multiSend = await multiSendFactory.deploy();
+                const guardFactory = await ethers.getContractFactory("DelegateCallTransactionGuard");
+                const tokenFactory = await ethers.getContractFactory("ERC20Token");
+                return {
+                    multiSend,
+                    guard: await guardFactory.deploy(multiSend),
+                    token: await tokenFactory.deploy(),
+                };
+            },
+        },
+    ];
+});

--- a/contracts/libraries/MultiSend.sol
+++ b/contracts/libraries/MultiSend.sol
@@ -62,9 +62,8 @@ contract MultiSend {
                     success := delegatecall(gas(), to, data, dataLength, 0, 0)
                 }
                 if eq(success, 0) {
-                    let errorLength := returndatasize()
-                    returndatacopy(0, 0, errorLength)
-                    revert(0, errorLength)
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
                 // Next entry starts at 85 byte + data length
                 i := add(i, add(0x55, dataLength))

--- a/contracts/libraries/MultiSendCallOnly.sol
+++ b/contracts/libraries/MultiSendCallOnly.sol
@@ -57,9 +57,8 @@ contract MultiSendCallOnly {
                     revert(0, 0)
                 }
                 if eq(success, 0) {
-                    let errorLength := returndatasize()
-                    returndatacopy(0, 0, errorLength)
-                    revert(0, errorLength)
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
                 // Next entry starts at 85 byte + data length
                 i := add(i, add(0x55, dataLength))

--- a/contracts/test/DelegateCaller.sol
+++ b/contracts/test/DelegateCaller.sol
@@ -15,9 +15,8 @@ contract DelegateCaller {
         if (!success) {
             /* solhint-disable no-inline-assembly */
             assembly {
-                let length := returndatasize()
-                returndatacopy(0, 0, length)
-                revert(0, length)
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
             }
             /* solhint-enable no-inline-assembly */
         }


### PR DESCRIPTION
This PR closes #734 by directly using the `returndatasize()` instead of storing it in memory and retrieving it later. ~Accessing `returndatasize()` is always cheaper than `mstore` and multiple `mload`'s~.

On checking further, it was found that there are no differences in terms of gas usage for transactions (extra tests were added for `MultiSend` to verify), while 1 byte is saved during deployment (checked using `codesize`).

Note: Benchmark failing in this PR is expected: [Source](https://github.com/safe-global/safe-smart-account/pull/736#issuecomment-1934037016)