### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,7 +543,7 @@ Note: **This contract is meant as an example to demonstrate how to facilitate a 
 
 Expected behaviour:
 
-This transaction guard can be used to prevent that Safe transactions can re-enter the `execTransaction` method. The transaction guard does not differentiate between different Safes, so if multiple Safes use the same guard instance it prevents entrancy in all of the connected Safes.
+This transaction guard can be used to prevent that Safe transactions can re-enter the `execTransaction` method. The transaction guard does not differentiate between different Safes, so if multiple Safes use the same guard instance it prevents reentrancy in all of the connected Safes.
 
 ### Libraries
 

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -162,7 +162,7 @@ contract Safe is
         {
             uint256 gasUsed = gasleft();
             // If the gasPrice is 0 we assume that nearly all available gas can be used (it is always more than safeTxGas)
-            // We only substract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than safeTxGas
+            // We only subtract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than safeTxGas
             success = execute(to, value, data, operation, gasPrice == 0 ? (gasleft() - 2500) : safeTxGas);
             gasUsed = gasUsed.sub(gasleft());
             // If no safeTxGas and no gasPrice was set (e.g. both are 0), then the internal tx is required to be successful

--- a/docs/audit_1_1_1.md
+++ b/docs/audit_1_1_1.md
@@ -6,7 +6,7 @@
   * Nick Munoz-McDonald (@NickErrant)
 
 ##### Notes
-All changes for 1.1.1 until commit [2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae](https://github.com/safe-global/safe-smart-account/commit/2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae) have been audited and the result were added to an ammended report.
+All changes for 1.1.1 until commit [2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae](https://github.com/safe-global/safe-smart-account/commit/2df0b2e0ad5d0f7ab5423e7f5baa72b2456d32ae) have been audited and the result were added to an amended report.
 
 All changes for 1.1.0 until commit [78494bcdbc61b3db52308a25f0556c42cf656ab1](https://github.com/safe-global/safe-smart-account/commit/78494bcdbc61b3db52308a25f0556c42cf656ab1) have been audited and are considered in the audit report.
 

--- a/test/core/Safe.ModuleManager.spec.ts
+++ b/test/core/Safe.ModuleManager.spec.ts
@@ -286,7 +286,7 @@ describe("ModuleManager", () => {
             expect(await mock.invocationCountForCalldata.staticCall("0xbaddad")).to.equal(1n);
         });
 
-        it("Returns expected from contract on successs", async () => {
+        it("Returns expected from contract on success", async () => {
             const {
                 safe,
                 mock,


### PR DESCRIPTION
1. Fix `CHANGELOG.md` typo
2. Fix `contracts/Safe.sol` typo
3. Fix `docs/audit_1_1_1.md` typo
4. Fix `test/core/Safe.ModuleManager.spec.ts` typo