### PR TITLE
Remove Leftover Testing Code In Harness Patch

### DIFF
--- a/certora/applyHarness.patch
+++ b/certora/applyHarness.patch
@@ -18,7 +18,7 @@ diff -druN base/Executor.sol base/Executor.sol
              /// @solidity memory-safe-assembly
 diff -druN interfaces/ISafe.sol interfaces/ISafe.sol
 --- interfaces/ISafe.sol	2024-04-18 13:33:47.817387950 +0200
-+++ interfaces/ISafe.sol	2024-04-18 13:36:59.528954360 +0200
++++ interfaces/ISafe.sol	2024-04-24 12:56:22.448349149 +0200
 @@ -109,7 +109,7 @@
       */
      function domainSeparator() external view returns (bytes32);
@@ -45,17 +45,10 @@ diff -druN interfaces/ISafe.sol interfaces/ISafe.sol
  
      /**
       * External getter function for state variables.
-@@ -167,4 +168,6 @@
-      * @return Number denoting if an owner approved the hash.
-      */
-     function approvedHashes(address owner, bytes32 messageHash) external view returns (uint256);
-+
-+    function ifoo() internal;
- }
 diff -druN Safe.sol Safe.sol
---- Safe.sol	2024-04-18 12:23:17.764702362 +0200
-+++ Safe.sol	2024-04-18 12:29:55.680464182 +0200
-@@ -72,22 +72,22 @@
+--- Safe.sol	2024-04-19 12:20:27.643013980 +0200
++++ Safe.sol	2024-04-24 12:57:47.960375971 +0200
+@@ -72,22 +72,24 @@
           * so we create a Safe with 0 owners and threshold 1.
           * This is an unusable Safe, perfect for the singleton
           */
@@ -63,10 +56,9 @@ diff -druN Safe.sol Safe.sol
 +        // threshold = 1; MUNGED: remove and add to constructor of the harness
      }
  
--    /**
--     * @inheritdoc ISafe
--     */
-+    // @inheritdoc ISafe
+     /**
+      * @inheritdoc ISafe
+      */
      function setup(
 -        address[] calldata _owners,
 +        address[] memory _owners,
@@ -85,7 +77,17 @@ diff -druN Safe.sol Safe.sol
          // setupOwners checks if the Threshold is already set, therefore preventing that this method is called twice
          setupOwners(_owners, _threshold);
          if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
-@@ -431,7 +431,8 @@
+@@ -417,9 +419,6 @@
+         return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeTxHash);
+     }
+ 
+-    /**
+-     * @inheritdoc ISafe
+-     */
+     function getTransactionHash(
+         address to,
+         uint256 value,
+@@ -431,7 +430,8 @@
          address gasToken,
          address refundReceiver,
          uint256 _nonce


### PR DESCRIPTION
#751 accidentally left some testing code in the harness patch which broke CI - this PR attempts to fix things.