### PR TITLE
Fix compilation issue with solidity versions >= 0.8.12

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -15,6 +15,11 @@ import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/IS
 import {SafeMath} from "./external/SafeMath.sol";
 import {ISafe} from "./interfaces/ISafe.sol";
 
+// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
+// the linter, so disable the `no-unused-imports` rule for the next line.
+// solhint-disable-next-line no-unused-import
+import {IModuleManager} from "./interfaces/IModuleManager.sol";
+
 /**
  * @title Safe - A multisignature wallet with support for confirmations using signed messages based on EIP-712.
  * @dev Most important concepts:
@@ -436,5 +441,20 @@ contract Safe is
         uint256 _nonce
     ) public view override returns (bytes32) {
         return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
+    }
+
+    /**
+     * @inheritdoc IModuleManager
+     */
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) public virtual override returns (bool success) {
+        (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
+
+        success = execute(to, value, data, operation, type(uint256).max);
+        postModuleExecution(guard, guardHash, success);
     }
 }

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -437,18 +437,4 @@ contract Safe is
     ) public view override returns (bytes32) {
         return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
     }
-
-    /**
-     * @inheritdoc ModuleManager
-     */
-    function _onExecTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation
-    ) internal virtual override returns (bool success) {
-        (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
-        success = execute(to, value, data, operation, type(uint256).max);
-        postModuleExecution(guard, guardHash, success);
-    }
 }

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -15,11 +15,6 @@ import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/IS
 import {SafeMath} from "./external/SafeMath.sol";
 import {ISafe} from "./interfaces/ISafe.sol";
 
-// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
-// the linter, so disable the `no-unused-imports` rule for the next line.
-// solhint-disable-next-line no-unused-import
-import {IModuleManager} from "./interfaces/IModuleManager.sol";
-
 /**
  * @title Safe - A multisignature wallet with support for confirmations using signed messages based on EIP-712.
  * @dev Most important concepts:
@@ -444,16 +439,15 @@ contract Safe is
     }
 
     /**
-     * @inheritdoc IModuleManager
+     * @inheritdoc ModuleManager
      */
-    function execTransactionFromModule(
+    function _onExecTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,
         Enum.Operation operation
-    ) public virtual override returns (bool success) {
+    ) internal virtual override returns (bool success) {
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
-
         success = execute(to, value, data, operation, type(uint256).max);
         postModuleExecution(guard, guardHash, success);
     }

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -76,13 +76,13 @@ contract SafeL2 is Safe {
     /**
      * @inheritdoc ModuleManager
      */
-    function _onExecTransactionFromModule(
+    function _onAfterExecTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,
-        Enum.Operation operation
-    ) internal override returns (bool success) {
+        Enum.Operation operation,
+        bool /*success*/
+    ) internal override {
         emit SafeModuleTransaction(msg.sender, to, value, data, operation);
-        success = super._onExecTransactionFromModule(to, value, data, operation);
     }
 }

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -3,9 +3,6 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import {Safe, Enum} from "./Safe.sol";
 
-// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
-// the linter, so disable the `no-unused-imports` rule for the next line.
-// solhint-disable-next-line no-unused-import
 import {ISafe} from "./interfaces/ISafe.sol";
 
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -2,6 +2,10 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Safe, Enum} from "./Safe.sol";
+
+// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
+// the linter, so disable the `no-unused-imports` rule for the next line.
+// solhint-disable-next-line no-unused-import
 import {ISafe} from "./interfaces/ISafe.sol";
 
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
@@ -72,7 +76,7 @@ contract SafeL2 is Safe {
     /**
      * @inheritdoc ModuleManager
      */
-    function _onAfterExecTransactionFromModule(
+    function onAfterExecTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -11,7 +11,7 @@ import {ISafe} from "./interfaces/ISafe.sol";
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
 // the linter, so disable the `no-unused-imports` rule for the next line.
 // solhint-disable-next-line no-unused-import
-import {IModuleManager} from "./interfaces/IModuleManager.sol";
+import {ModuleManager} from "./base/ModuleManager.sol";
 
 /**
  * @title SafeL2 - An implementation of the Safe contract that emits additional events on transaction executions.
@@ -74,15 +74,15 @@ contract SafeL2 is Safe {
     }
 
     /**
-     * @inheritdoc IModuleManager
+     * @inheritdoc ModuleManager
      */
-    function execTransactionFromModule(
+    function _onExecTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,
         Enum.Operation operation
-    ) public override returns (bool success) {
+    ) internal override returns (bool success) {
         emit SafeModuleTransaction(msg.sender, to, value, data, operation);
-        success = super.execTransactionFromModule(to, value, data, operation);
+        success = super._onExecTransactionFromModule(to, value, data, operation);
     }
 }

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -6,7 +6,12 @@ import {Safe, Enum} from "./Safe.sol";
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
 // the linter, so disable the `no-unused-imports` rule for the next line.
 // solhint-disable-next-line no-unused-import
-import {ISafe, IModuleManager} from "./interfaces/ISafe.sol";
+import {ISafe} from "./interfaces/ISafe.sol";
+
+// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
+// the linter, so disable the `no-unused-imports` rule for the next line.
+// solhint-disable-next-line no-unused-import
+import {IModuleManager} from "./interfaces/IModuleManager.sol";
 
 /**
  * @title SafeL2 - An implementation of the Safe contract that emits additional events on transaction executions.

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Safe, Enum} from "./Safe.sol";
-
 import {ISafe} from "./interfaces/ISafe.sol";
 
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -7,9 +7,6 @@ import {Safe, Enum} from "./Safe.sol";
 // the linter, so disable the `no-unused-imports` rule for the next line.
 // solhint-disable-next-line no-unused-import
 import {ISafe} from "./interfaces/ISafe.sol";
-
-// Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
-// the linter, so disable the `no-unused-imports` rule for the next line.
 // solhint-disable-next-line no-unused-import
 import {ModuleManager} from "./base/ModuleManager.sol";
 

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -286,5 +286,9 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         uint256 value,
         bytes memory data,
         Enum.Operation operation
-    ) internal virtual returns (bool success);
+    ) internal virtual returns (bool success) {
+        (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
+        success = execute(to, value, data, operation, type(uint256).max);
+        postModuleExecution(guard, guardHash, success);
+    }
 }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -292,7 +292,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
      * @param operation Operation type of module transaction.
      * @param success Boolean flag indicating if the call succeeded.
      */
-    function _onAfterExecTransactionFromModule(
+    function onAfterExecTransactionFromModule(
         address to,
         uint256 value,
         bytes memory data,

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -125,7 +125,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         }
         if (success) emit ExecutionFromModuleSuccess(msg.sender);
         else emit ExecutionFromModuleFailure(msg.sender);
-        _onAfterExecTransactionFromModule(to, value, data, operation, success);
+        onAfterExecTransactionFromModule(to, value, data, operation, success);
     }
 
     /**

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -147,6 +147,18 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
     /**
      * @inheritdoc IModuleManager
      */
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) public override returns (bool success) {
+        return _onExecTransactionFromModule(to, value, data, operation);
+    }
+
+    /**
+     * @inheritdoc IModuleManager
+     */
     function execTransactionFromModuleReturnData(
         address to,
         uint256 value,
@@ -260,4 +272,19 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
             moduleGuard := sload(slot)
         }
     }
+
+    /**
+     * @notice This method gets called by execTransactionFromModule function.
+     * @param to Destination address of module transaction.
+     * @param value Ether value of module transaction.
+     * @param data Data payload of module transaction.
+     * @param operation Operation type of module transaction.
+     * @return success Boolean flag indicating if the call succeeded.
+     */
+    function _onExecTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) internal virtual returns (bool success);
 }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -285,7 +285,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
     }
 
     /**
-     * @notice A hook that gets called after execution of execTransactionFromModule method.
+     * @notice A hook that gets called after execution of {execTransactionFromModule*} methods.
      * @param to Destination address of module transaction.
      * @param value Ether value of module transaction.
      * @param data Data payload of module transaction.

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -147,21 +147,6 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
     /**
      * @inheritdoc IModuleManager
      */
-    function execTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation
-    ) public virtual override returns (bool success) {
-        (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
-
-        success = execute(to, value, data, operation, type(uint256).max);
-        postModuleExecution(guard, guardHash, success);
-    }
-
-    /**
-     * @inheritdoc IModuleManager
-     */
     function execTransactionFromModuleReturnData(
         address to,
         uint256 value,

--- a/test/l2/Safe.Execution.spec.ts
+++ b/test/l2/Safe.Execution.spec.ts
@@ -89,5 +89,22 @@ describe("SafeL2", () => {
                 .to.emit(safe, "ExecutionFromModuleSuccess")
                 .withArgs(user2.address);
         });
+
+        it("should emit SafeModuleTransaction event in execTransactionFromModuleReturnData", async () => {
+            const {
+                safe,
+                mock,
+                signers: [user1, user2],
+            } = await setupTests();
+            const mockAddress = await mock.getAddress();
+            const user2Safe = safe.connect(user2);
+            await executeContractCallWithSigners(safe, safe, "enableModule", [user2.address], [user1]);
+
+            await expect(user2Safe.execTransactionFromModuleReturnData(mockAddress, 0, "0xbaddad", 0))
+                .to.emit(safe, "SafeModuleTransaction")
+                .withArgs(user2.address, mockAddress, 0, "0xbaddad", 0)
+                .to.emit(safe, "ExecutionFromModuleSuccess")
+                .withArgs(user2.address);
+        });
     });
 });


### PR DESCRIPTION
Fixes: #735 and #773

### Changes in PR
- Add a hook function `_onAfterExecTransactionFromModule` that gets called after execution from module.
- SafeL2 overrides this function to emit event `SafeModuleTransaction`.
- Add test that checks if `execTransactionFromModuleReturnData` in SafeL2 emits `SafeModuleTransaction` event.

#### Codesize increase by `33` bytes with compiler version 0.7.6 

#### This PR:

```
Safe 21814 bytes (limit is 24576)
SafeL2 22632 bytes (limit is 24576)
```

#### Main branch
```
Safe 21781 bytes (limit is 24576)
SafeL2 22623 bytes (limit is 24576)
```


### Impact on gas usage with `Safe` contract

Changes in this PR add additional overhead of `49` gas

####  This PR:

```
·------------------------------------------------------------|----------------------------|-------------|------------------------------·
|                    Solc version: 0.7.6                     ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 100000000 gas  │
·····························································|····························|·············|·······························
|  Methods                                                                                                                             │
·····················|·······································|·············|··············|·············|···············|···············
|  Contract          ·  Method                               ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)   │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModule            ·      51630  ·      184223  ·     127865  ·           11  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModuleReturnData  ·      52273  ·      183979  ·     107919  ·            5  ·           -  │
```

#### Main branch

```
·------------------------------------------------------------|----------------------------|-------------|------------------------------·
|                    Solc version: 0.7.6                     ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 100000000 gas  │
·····························································|····························|·············|·······························
|  Methods                                                                                                                             │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModule            ·      51581  ·      184186  ·     127818  ·           11  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModuleReturnData  ·      52224  ·      183930  ·     107870  ·            5  ·           -  │
```

Why this approach?
- Clean code
- Introduces a hook that allows contracts inheriting Safe to do additional post processing.


**Alternatives considered**
A.
- Move the function `execTransactionFromModule(...)` from `ModuleManager` to `Safe` contract. https://github.com/safe-global/safe-smart-account/pull/772/commits/3521a4bd8b468ef5ae517729898f8bbc1fc325fa
- But this is not an ideal approach as `ModuleManager` does not implement `execTransactionFromModule`.
- Pro: Minimal code changes, no impact on codesize

B.
- Create `_onExecTransactionFromModule` method that gets called by `execTransactionFromModule` 
- ~~Con: This approach still has repeating code~~
- Approach is similar to `A` with new function. Here, `_onExecTransactionFromModule` still calls its parent.
- Pro: Increase in codesize by only `24` bytes

Side note:

Why event `SafeModuleTransaction` is not emitted by `execTransactionFromModuleReturnData` in `SafeL2`?  Why `SafeL2` does not override `execTransactionFromModuleReturnData`.
-> `execTransactionFromModuleReturnData` in `SafeL2` should also emit event. Might have been missed in the past. ~~Would be covered in a separate PR.~~. This PR fixes the issue.