### PR TITLE
Create a pre call hook onBeforeExecTransaction

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -445,7 +445,6 @@ contract Safe is
      * @param value Ether value of module transaction.
      * @param data Data payload of module transaction.
      * @param operation Operation type of module transaction.
-     * @param success Boolean flag indicating if the call succeeded.
      */
     function onBeforeExecTransaction(
         address to,
@@ -457,7 +456,6 @@ contract Safe is
         uint256 gasPrice,
         address gasToken,
         address payable refundReceiver,
-        bytes memory signatures,
-        bool success
+        bytes memory signatures
     ) internal virtual {}
 }

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -119,7 +119,7 @@ contract Safe is
         address gasToken,
         address payable refundReceiver,
         bytes memory signatures
-    ) public payable virtual override returns (bool success) {
+    ) external payable override returns (bool success) {
         onBeforeExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures);
         bytes32 txHash;
         // Use scope here to limit variable lifetime and prevent `stack too deep` errors

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -120,6 +120,7 @@ contract Safe is
         address payable refundReceiver,
         bytes memory signatures
     ) public payable virtual override returns (bool success) {
+        onBeforeExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, success);
         bytes32 txHash;
         // Use scope here to limit variable lifetime and prevent `stack too deep` errors
         {
@@ -188,7 +189,6 @@ contract Safe is
                 ITransactionGuard(guard).checkAfterExecution(txHash, success);
             }
         }
-        onAfterExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, success);
     }
 
     /**
@@ -440,14 +440,14 @@ contract Safe is
     }
 
     /**
-     * @notice A hook that gets called after execution of {execTransaction} method.
+     * @notice A hook that gets called before execution of {execTransaction} method.
      * @param to Destination address of module transaction.
      * @param value Ether value of module transaction.
      * @param data Data payload of module transaction.
      * @param operation Operation type of module transaction.
      * @param success Boolean flag indicating if the call succeeded.
      */
-    function onAfterExecTransaction(
+    function onBeforeExecTransaction(
         address to,
         uint256 value,
         bytes calldata data,

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -188,6 +188,7 @@ contract Safe is
                 ITransactionGuard(guard).checkAfterExecution(txHash, success);
             }
         }
+        onAfterExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, success);
     }
 
     /**
@@ -437,4 +438,26 @@ contract Safe is
     ) public view override returns (bytes32) {
         return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
     }
+
+    /**
+     * @notice A hook that gets called after execution of {execTransaction} method.
+     * @param to Destination address of module transaction.
+     * @param value Ether value of module transaction.
+     * @param data Data payload of module transaction.
+     * @param operation Operation type of module transaction.
+     * @param success Boolean flag indicating if the call succeeded.
+     */
+    function onAfterExecTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        bool success
+    ) internal virtual {}
 }

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -120,7 +120,7 @@ contract Safe is
         address payable refundReceiver,
         bytes memory signatures
     ) public payable virtual override returns (bool success) {
-        onBeforeExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures, success);
+        onBeforeExecTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures);
         bytes32 txHash;
         // Use scope here to limit variable lifetime and prevent `stack too deep` errors
         {

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -38,7 +38,7 @@ contract SafeL2 is Safe {
     /**
      * @inheritdoc Safe
      */
-    function onAfterExecTransaction(
+    function onBeforeExecTransaction(
         address to,
         uint256 value,
         bytes calldata data,
@@ -53,7 +53,7 @@ contract SafeL2 is Safe {
     ) internal override {
         bytes memory additionalInfo;
         {
-            additionalInfo = abi.encode(nonce - 1, msg.sender, threshold);
+            additionalInfo = abi.encode(nonce, msg.sender, threshold);
         }
         emit SafeMultiSigTransaction(
             to,

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -6,8 +6,6 @@ import {Safe, Enum} from "./Safe.sol";
 // Imports are required for NatSpec validation of the compiler, and falsely detected as unused by
 // the linter, so disable the `no-unused-imports` rule for the next line.
 // solhint-disable-next-line no-unused-import
-import {ISafe} from "./interfaces/ISafe.sol";
-// solhint-disable-next-line no-unused-import
 import {ModuleManager} from "./base/ModuleManager.sol";
 
 /**

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -48,8 +48,7 @@ contract SafeL2 is Safe {
         uint256 gasPrice,
         address gasToken,
         address payable refundReceiver,
-        bytes memory signatures,
-        bool /*success*/
+        bytes memory signatures
     ) internal override {
         bytes memory additionalInfo;
         {

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -36,9 +36,9 @@ contract SafeL2 is Safe {
     event SafeModuleTransaction(address module, address to, uint256 value, bytes data, Enum.Operation operation);
 
     /**
-     * @inheritdoc ISafe
+     * @inheritdoc Safe
      */
-    function execTransaction(
+    function onAfterExecTransaction(
         address to,
         uint256 value,
         bytes calldata data,
@@ -48,11 +48,12 @@ contract SafeL2 is Safe {
         uint256 gasPrice,
         address gasToken,
         address payable refundReceiver,
-        bytes memory signatures
-    ) public payable override returns (bool) {
+        bytes memory signatures,
+        bool /*success*/
+    ) internal override {
         bytes memory additionalInfo;
         {
-            additionalInfo = abi.encode(nonce, msg.sender, threshold);
+            additionalInfo = abi.encode(nonce - 1, msg.sender, threshold);
         }
         emit SafeMultiSigTransaction(
             to,
@@ -67,7 +68,6 @@ contract SafeL2 is Safe {
             signatures,
             additionalInfo
         );
-        return super.execTransaction(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, signatures);
     }
 
     /**

--- a/contracts/SafeL2.sol
+++ b/contracts/SafeL2.sol
@@ -73,13 +73,7 @@ contract SafeL2 is Safe {
     /**
      * @inheritdoc ModuleManager
      */
-    function onAfterExecTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        bool /*success*/
-    ) internal override {
+    function onBeforeExecTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation) internal override {
         emit SafeModuleTransaction(msg.sender, to, value, data, operation);
     }
 }

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -152,7 +152,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         uint256 value,
         bytes memory data,
         Enum.Operation operation
-    ) public override returns (bool success) {
+    ) external override returns (bool success) {
         onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -167,7 +167,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         uint256 value,
         bytes memory data,
         Enum.Operation operation
-    ) public override returns (bool success, bytes memory returnData) {
+    ) external override returns (bool success, bytes memory returnData) {
         onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -94,6 +94,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         bytes memory data,
         Enum.Operation operation
     ) internal returns (address guard, bytes32 guardHash) {
+        onBeforeExecTransactionFromModule(to, value, data, operation);
         guard = getModuleGuard();
 
         // Only whitelisted modules are allowed.
@@ -153,7 +154,6 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         bytes memory data,
         Enum.Operation operation
     ) external override returns (bool success) {
-        onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);
         postModuleExecution(guard, guardHash, success);
@@ -168,7 +168,6 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         bytes memory data,
         Enum.Operation operation
     ) external override returns (bool success, bytes memory returnData) {
-        onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);
         /* solhint-disable no-inline-assembly */

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -153,10 +153,10 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         bytes memory data,
         Enum.Operation operation
     ) public override returns (bool success) {
+        onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);
         postModuleExecution(guard, guardHash, success);
-        onAfterExecTransactionFromModule(to, value, data, operation, success);
     }
 
     /**
@@ -168,6 +168,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         bytes memory data,
         Enum.Operation operation
     ) public override returns (bool success, bytes memory returnData) {
+        onBeforeExecTransactionFromModule(to, value, data, operation);
         (address guard, bytes32 guardHash) = preModuleExecution(to, value, data, operation);
         success = execute(to, value, data, operation, type(uint256).max);
         /* solhint-disable no-inline-assembly */
@@ -185,7 +186,6 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         }
         /* solhint-enable no-inline-assembly */
         postModuleExecution(guard, guardHash, success);
-        onAfterExecTransactionFromModule(to, value, data, operation, success);
     }
 
     /**
@@ -278,18 +278,11 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
     }
 
     /**
-     * @notice A hook that gets called after execution of {execTransactionFromModule*} methods.
+     * @notice A hook that gets called before execution of {execTransactionFromModule*} methods.
      * @param to Destination address of module transaction.
      * @param value Ether value of module transaction.
      * @param data Data payload of module transaction.
      * @param operation Operation type of module transaction.
-     * @param success Boolean flag indicating if the call succeeded.
      */
-    function onAfterExecTransactionFromModule(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        bool success
-    ) internal virtual {}
+    function onBeforeExecTransactionFromModule(address to, uint256 value, bytes memory data, Enum.Operation operation) internal virtual {}
 }

--- a/test/core/Safe.Execution.spec.ts
+++ b/test/core/Safe.Execution.spec.ts
@@ -216,7 +216,7 @@ describe("Safe", () => {
             const receipt = await hre.ethers.provider.getTransactionReceipt(executedTx!.hash);
             const receiptLogs = receipt?.logs ?? [];
 
-            const logIndex = 0;
+            const logIndex = receiptLogs.length - 1;
 
             const successEvent = safe.interface.decodeEventLog(
                 "ExecutionSuccess",
@@ -258,7 +258,7 @@ describe("Safe", () => {
             ).to.emit(safe, "ExecutionFailure");
             const receipt = await hre.ethers.provider.getTransactionReceipt(executedTx!.hash);
             const receiptLogs = receipt?.logs ?? [];
-            const logIndex = 0;
+            const logIndex = receiptLogs.length - 1;
             const successEvent = safe.interface.decodeEventLog(
                 "ExecutionFailure",
                 receiptLogs[logIndex].data,

--- a/test/core/Safe.Execution.spec.ts
+++ b/test/core/Safe.Execution.spec.ts
@@ -203,7 +203,7 @@ describe("Safe", () => {
 
             await user1.sendTransaction({ to: safeAddress, value: ethers.parseEther("1") });
             const userBalance = await hre.ethers.provider.getBalance(user2.address);
-            await expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.eq(ethers.parseEther("1"));
+            expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.eq(ethers.parseEther("1"));
 
             let executedTx: any;
             await expect(
@@ -212,9 +212,12 @@ describe("Safe", () => {
                     return tx;
                 }),
             ).to.emit(safe, "ExecutionSuccess");
+
             const receipt = await hre.ethers.provider.getTransactionReceipt(executedTx!.hash);
             const receiptLogs = receipt?.logs ?? [];
-            const logIndex = receiptLogs.length - 1;
+
+            const logIndex = 0;
+
             const successEvent = safe.interface.decodeEventLog(
                 "ExecutionSuccess",
                 receiptLogs[logIndex].data,
@@ -223,7 +226,7 @@ describe("Safe", () => {
             expect(successEvent.txHash).to.be.eq(calculateSafeTransactionHash(safeAddress, tx, await chainId()));
             // Gas costs are around 3000, so even if we specified a safeTxGas from 100000 we should not use more
             expect(successEvent.payment).to.be.lte(5000n);
-            await expect(await hre.ethers.provider.getBalance(user2.address)).to.eq(userBalance + successEvent.payment);
+            expect(await hre.ethers.provider.getBalance(user2.address)).to.eq(userBalance + successEvent.payment);
         });
 
         it("should emit payment in failure event", async () => {
@@ -255,7 +258,7 @@ describe("Safe", () => {
             ).to.emit(safe, "ExecutionFailure");
             const receipt = await hre.ethers.provider.getTransactionReceipt(executedTx!.hash);
             const receiptLogs = receipt?.logs ?? [];
-            const logIndex = receiptLogs.length - 1;
+            const logIndex = 0;
             const successEvent = safe.interface.decodeEventLog(
                 "ExecutionFailure",
                 receiptLogs[logIndex].data,

--- a/test/l2/Safe.Execution.spec.ts
+++ b/test/l2/Safe.Execution.spec.ts
@@ -37,16 +37,19 @@ describe("SafeL2", () => {
             } = await setupTests();
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({
-                to: user1.address,
+                to: safeAddress,
                 nonce: await safe.nonce(),
                 operation: 0,
                 gasPrice: 1,
-                safeTxGas: 100000,
+                safeTxGas: 1000000,
+                // addOwnerWithThreshold is specifically chosen here in this test because additionalInfo in the SafeMultiSigTransaction event has threshold value.
+                // The test here also checks if the threshold value prior to Safe state change is emitted in the event.
+                data: safe.interface.encodeFunctionData("addOwnerWithThreshold", [user2.address, 2]),
                 refundReceiver: user2.address,
             });
 
             await user1.sendTransaction({ to: safeAddress, value: ethers.parseEther("1") });
-            expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.deep.eq(ethers.parseEther("1"));
+            await expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.deep.eq(ethers.parseEther("1"));
 
             const additionalInfo = ethers.AbiCoder.defaultAbiCoder().encode(
                 ["uint256", "address", "uint256"],

--- a/test/l2/Safe.Execution.spec.ts
+++ b/test/l2/Safe.Execution.spec.ts
@@ -46,7 +46,7 @@ describe("SafeL2", () => {
             });
 
             await user1.sendTransaction({ to: safeAddress, value: ethers.parseEther("1") });
-            await expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.deep.eq(ethers.parseEther("1"));
+            expect(await hre.ethers.provider.getBalance(safeAddress)).to.be.deep.eq(ethers.parseEther("1"));
 
             const additionalInfo = ethers.AbiCoder.defaultAbiCoder().encode(
                 ["uint256", "address", "uint256"],


### PR DESCRIPTION
Fixes #775, #735

To have a broader context on overall changes in the code use this [diff](https://github.com/safe-global/safe-smart-account/compare/499b17ad..improvement-execTransaction-post-call-hook)

### Changes in PR:
- Add a pre-hook function onBeforeExecTransaction
- Refactor changes in #772, #774
- Add a pre-hook function onBeforeExecTransactionFromModule
- Change function visibility of execTransaction from public to external

### Code size change

Increase by 51 bytes in Safe with diff: https://github.com/safe-global/safe-smart-account/compare/499b17ad..improvement-execTransaction-post-call-hook:

#### This PR
```
Safe 21832 bytes (limit is 24576)
SafeL2 22612 bytes (limit is 24576)
```

#### [Commit](https://github.com/safe-global/safe-smart-account/commit/499b17ad0191b575fcadc5cb5b8e3faeae5391ae) (Prior to merging #772)

```
Safe 21781 bytes (limit is 24576)
SafeL2 22623 bytes (limit is 24576)
```

### Gas usage with Safe contract

- Increase by 79 gas in execTransaction calls
- Increase by 44 gas in execTransactionFromModule* calls

#### This PR

```
·------------------------------------------------------------|----------------------------|-------------|------------------------------·
|                    Solc version: 0.7.6                     ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 100000000 gas  │
·····························································|····························|·············|·······························
|  Methods                                                                                                                             │
·····················|·······································|·············|··············|·············|···············|···············
|  Contract          ·  Method                               ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)   │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransaction                      ·      51999  ·     3638489  ·     133046  ·          248  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModule            ·      51625  ·      184218  ·     127860  ·           11  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModuleReturnData  ·      52268  ·      183974  ·     107914  ·            5  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
```

#### [Commit](https://github.com/safe-global/safe-smart-account/commit/499b17ad0191b575fcadc5cb5b8e3faeae5391ae) (Prior to merging #772)

```
·------------------------------------------------------------|----------------------------|-------------|------------------------------·
|                    Solc version: 0.7.6                     ·  Optimizer enabled: false  ·  Runs: 200  ·  Block limit: 100000000 gas  │
·····························································|····························|·············|·······························
|  Methods                                                                                                                             │
·····················|·······································|·············|··············|·············|···············|···············
|  Contract          ·  Method                               ·  Min        ·  Max         ·  Avg        ·  # calls      ·  usd (avg)   │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransaction                      ·      51920  ·     3638410  ·     132980  ·          248  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModule            ·      51581  ·      184186  ·     127818  ·           11  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
|  Safe              ·  execTransactionFromModuleReturnData  ·      52224  ·      183930  ·     107870  ·            5  ·           -  │
·····················|·······································|·············|··············|·············|···············|···············
```

### Alternatives considered
A.

Add a post call hook `onAfterExecTransaction`

Cons: 
- If a transaction updates threshold of a Safe, then event emits new threshold rather than emitting the value prior to the update. I tried adding `additionalInfo` as a method parameter and building this value prior to the execution but compiler reports CompilerError: `Stack too deep, try removing local variables`. 
- Changes order of emitted events.