### PR TITLE
Add stricter checks on signature length

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -227,6 +227,7 @@ contract Safe is
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param signatures Signature data that should be verified.
      * @param offset Offset to the start of the contract signature in the signatures byte array
+     * @return newOffset The new offset that points to the end of the contract signature
      */
     function checkContractSignature(
         address owner,
@@ -298,9 +299,7 @@ contract Safe is
                 // When handling contract signatures the address of the contract is encoded into r
                 currentOwner = address(uint160(uint256(r)));
 
-                // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
-                // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
-                // Here we only check that the pointer is not pointing inside the part that is being processed
+                // Require that the signature data pointer is pointing to the expected location, at the end of processed contract signatures.
                 if (uint256(s) != offset) revertWithError("GS021");
 
                 // The contract signature check is extracted to a separate function for better compatibility with formal verification
@@ -328,7 +327,7 @@ contract Safe is
             lastOwner = currentOwner;
         }
         // if the signature is longer than the offset, it means that there are extra bytes not used in the signature
-
+        // A side effect of this check is that it will fail if the signatures count sent in the transaction is more than the required threshold
         if (signatures.length != offset) revertWithError("GS028");
     }
 

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -19,6 +19,9 @@
 - `GS024`: `Invalid contract signature provided`
 - `GS025`: `Hash has not been approved`
 - `GS026`: `Invalid owner provided`
+- `GS028`: `Invalid signature length`
+
+Deprecated:  `GS027`: `Invalid signature provided`
 
 ### General auth related
 - `GS030`: `Only owners can approve a hash`

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -117,12 +117,19 @@ describe("CompatibilityFallbackHandler", () => {
             const signerSafeMessageHash = calculateSafeMessageHash(signerSafeAddress, validatorSafeMessageHash, await chainId());
 
             const signerSafeOwnerSignature = await signHash(user1, signerSafeMessageHash);
-
             const signerSafeSig = buildContractSignature(signerSafeAddress, signerSafeOwnerSignature.data);
 
-            expect(
-                await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes([typedDataSig, ethSignSig, signerSafeSig])),
-            ).to.be.eq("0x1626ba7e");
+            expect(await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes([typedDataSig, ethSignSig]))).to.be.eq(
+                "0x1626ba7e",
+            );
+
+            expect(await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes([signerSafeSig, ethSignSig]))).to.be.eq(
+                "0x1626ba7e",
+            );
+
+            expect(await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes([typedDataSig, signerSafeSig]))).to.be.eq(
+                "0x1626ba7e",
+            );
         });
     });
 

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import hre, { deployments, ethers } from "hardhat";
 import { AddressZero } from "@ethersproject/constants";
-import { defaultAbiCoder } from "@ethersproject/abi";
 import { getSafeWithOwners, deployContract, getCompatFallbackHandler } from "../utils/setup";
 import { buildSignatureBytes, executeContractCallWithSigners, signHash } from "../../src/utils/execution";
 
@@ -49,9 +48,8 @@ describe("Safe", () => {
             // Use off-chain Safe signature
             const transactionHash = await safe.getTransactionHash(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
             const messageHash = await messageHandler.getMessageHash(transactionHash);
-            const ownerSigs = await buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
-            const encodedOwnerSigns = defaultAbiCoder.encode(["bytes"], [ownerSigs]).slice(66);
-
+            const ownerSigs = buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
+            const encodedOwnerSigns = ((ownerSigs.length - 2) / 2).toString(16).padStart(64, "00") + ownerSigs.slice(2);
             // Use EOA owner
             let sigs =
                 "0x" +
@@ -76,7 +74,6 @@ describe("Safe", () => {
                 "0000000000000000000000000000000000000000000000000000000000000041" +
                 "00" + // r, s, v
                 encodedOwnerSigns;
-
             await safe.execTransaction(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, sigs);
 
             // Safe should be empty again
@@ -127,8 +124,8 @@ describe("Safe", () => {
             // Use off-chain Safe signature
             const transactionHash = await safe.getTransactionHash(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
             const messageHash = await messageHandler.getMessageHash(transactionHash);
-            const ownerSigs = await buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
-            const encodedOwnerSigns = defaultAbiCoder.encode(["bytes"], [ownerSigs]).slice(66);
+            const ownerSigs = buildSignatureBytes([await signHash(user1, messageHash), await signHash(user2, messageHash)]);
+            const encodedOwnerSigns = ((ownerSigs.length - 2) / 2).toString(16).padStart(64, "00") + ownerSigs.slice(2);
 
             // Use Safe owner
             const sigs =


### PR DESCRIPTION
Fixes #754 

Changes in PR:

- `Safe` contract checks if signature data does not contain additional bytes data than required
- Fix tests
    - In Ethers.js defaultAbiCoder pads the bytes data to nearest word which appends additional zeros to signature data. This lead to failing test
    - Submit only required number of signatures in Compatibility Fallback Handler tests

Problem:
If the signatures payload contains more approvals from owners than required `threshold`, the signature validation will fail.