### PR TITLE
Update ModuleManager.sol

### DIFF
--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -206,7 +206,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         // Populate return array
         uint256 moduleCount = 0;
         next = modules[start];
-        while (next != address(0) && next != SENTINEL_MODULES && moduleCount < pageSize) {
+        while (next != address(0) && moduleCount < pageSize) {
             array[moduleCount] = next;
             next = modules[next];
             moduleCount++;
@@ -214,15 +214,18 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
 
         /**
           Because of the argument validation, we can assume that the loop will always iterate over the valid module list values
-          and the `next` variable will either be an enabled module or a sentinel address (signalling the end). 
+          and the `next` variable will either be an enabled module.
+          
+          Based on the previous validation code, we can assume that next will never be a sentinel address(as it denotes the start),
+          as the check start != SENTINEL_MODULES has already been performed.
           
           If we haven't reached the end inside the loop, we need to set the next pointer to the last element of the modules array
           because the `next` variable (which is a module by itself) acting as a pointer to the start of the next page is neither 
           included to the current page, nor will it be included in the next one if you pass it as a start.
         */
-        if (next != SENTINEL_MODULES) {
-            next = array[moduleCount - 1];
-        }
+        
+        next = array[moduleCount - 1];
+        
         // Set correct size of returned array
         /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly


### PR DESCRIPTION
Based on the setupModules and enableModule methods in the ModuleManager, we can ascertain that SENTINEL_MODULES points to the head node. The linked list can be represented as follows: SENTINEL_MODULES --> newModule --> ModuleA --> ModuleB --> ModuleC --> address(0x01).

Given this, isn't there redundancy in the getModulesPaginated method? For example, the check next != SENTINEL_MODULES seems redundant because next can never be SENTINEL_MODULES as it points to the head node. Moreover, the first line of the getModulesPaginated method already ensures that start != SENTINEL_MODULES.