### PR TITLE
`getSafeWithOwners` using types

### DIFF
--- a/benchmark/utils/setup.ts
+++ b/benchmark/utils/setup.ts
@@ -24,15 +24,13 @@ const generateTarget = async (owners: number, threshold: number, guardAddress: s
     const fallbackHandler = await getTokenCallbackHandler();
     const fallbackHandlerAddress = await fallbackHandler.getAddress();
     const signers = (await ethers.getSigners()).slice(0, owners);
-    const safe = await getSafeWithOwners(
-        signers.map((owner) => owner.address),
-        threshold,
-        ethers.ZeroAddress,
-        "0x",
-        fallbackHandlerAddress,
-        logGasUsage,
-        saltNumber,
-    );
+    const safe = await getSafeWithOwners({
+        owners: signers.map((owner) => owner.address),
+        threshold: threshold,
+        fallbackHandler: fallbackHandlerAddress,
+        logGasUsage: logGasUsage,
+        saltNumber: saltNumber,
+    });
     await executeContractCallWithSigners(safe, safe, "setGuard", [guardAddress], signers);
     return safe;
 };

--- a/benchmark/utils/setup.ts
+++ b/benchmark/utils/setup.ts
@@ -26,10 +26,10 @@ const generateTarget = async (owners: number, threshold: number, guardAddress: s
     const signers = (await ethers.getSigners()).slice(0, owners);
     const safe = await getSafeWithOwners({
         owners: signers.map((owner) => owner.address),
-        threshold: threshold,
+        threshold,
         fallbackHandler: fallbackHandlerAddress,
-        logGasUsage: logGasUsage,
-        saltNumber: saltNumber,
+        logGasUsage,
+        saltNumber,
     });
     await executeContractCallWithSigners(safe, safe, "setGuard", [guardAddress], signers);
     return safe;

--- a/test/accessors/SimulateTxAccessor.spec.ts
+++ b/test/accessors/SimulateTxAccessor.spec.ts
@@ -20,7 +20,7 @@ describe("SimulateTxAccessor", () => {
         const interactor = await deployContract(user1, source);
         const handler = await getCompatFallbackHandler();
         const handlerAddress = await handler.getAddress();
-        const safe = await getSafeWithOwners([user1.address], 1, ethers.ZeroAddress, "0x", handlerAddress);
+        const safe = await getSafeWithOwners({ owners: [user1.address], threshold: 1, fallbackHandler: handlerAddress });
         const safeAddress = await safe.getAddress();
         const simulator = await getCompatFallbackHandler(safeAddress);
         return {

--- a/test/core/Safe.Execution.spec.ts
+++ b/test/core/Safe.Execution.spec.ts
@@ -42,7 +42,7 @@ describe("Safe", () => {
             }`;
         const reverter = await deployContract(user1, reverterSource);
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             reverter,
             storageSetter,
             nativeTokenReceiver,

--- a/test/core/Safe.GuardManager.spec.ts
+++ b/test/core/Safe.GuardManager.spec.ts
@@ -26,7 +26,7 @@ describe("GuardManager", () => {
         const guardContract = await hre.ethers.getContractAt("ITransactionGuard", AddressZero);
         const guardEip165Calldata = guardContract.interface.encodeFunctionData("supportsInterface", ["0xe6d7a83a"]);
         await validGuardMock.givenCalldataReturnBool(guardEip165Calldata, true);
-        const safe = await getSafeWithOwners([user2.address]);
+        const safe = await getSafeWithOwners({ owners: [user2.address] });
         await executeContractCallWithSigners(safe, safe, "setGuard", [validGuardMockAddress], [user2]);
 
         return {
@@ -42,7 +42,7 @@ describe("GuardManager", () => {
             const {
                 signers: [user1, user2],
             } = await setupWithTemplate();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await expect(executeContractCallWithSigners(safe, safe, "setGuard", [user2.address], [user1])).to.be.revertedWith("GS013");
         });
@@ -53,7 +53,7 @@ describe("GuardManager", () => {
                 signers: [user1],
             } = await setupWithTemplate();
             const validGuardMockAddress = await validGuardMock.getAddress();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await expect(executeContractCallWithSigners(safe, safe, "setGuard", [validGuardMockAddress], [user1]))
                 .to.emit(safe, "ChangedGuard")
@@ -72,7 +72,7 @@ describe("GuardManager", () => {
 
             const invocationCountBefore = await validGuardMock.invocationCount();
             const validGuardMockAddress = await validGuardMock.getAddress();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await executeContractCallWithSigners(safe, safe, "setGuard", [validGuardMockAddress], [user1]);
 

--- a/test/core/Safe.Incoming.spec.ts
+++ b/test/core/Safe.Incoming.spec.ts
@@ -21,7 +21,7 @@ describe("Safe", () => {
         const signers = await ethers.getSigners();
         const [user1] = signers;
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             caller: await deployContract(user1, source),
             signers,
         };

--- a/test/core/Safe.ModuleManager.spec.ts
+++ b/test/core/Safe.ModuleManager.spec.ts
@@ -13,7 +13,7 @@ describe("ModuleManager", () => {
         const signers = await ethers.getSigners();
         const [user1] = signers;
 
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
 
         const validModuleGuardMock = await getMock();
         const moduleGuardContract = await hre.ethers.getContractAt("IModuleGuard", AddressZero);
@@ -577,7 +577,7 @@ describe("ModuleManager", () => {
             const {
                 signers: [user1, user2],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await expect(executeContractCallWithSigners(safe, safe, "setModuleGuard", [user2.address], [user1])).to.be.revertedWith(
                 "GS013",
@@ -590,7 +590,7 @@ describe("ModuleManager", () => {
                 signers: [user1],
             } = await setupTests();
             const validGuardMockAddress = await validModuleGuardMock.getAddress();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await expect(executeContractCallWithSigners(safe, safe, "setModuleGuard", [validGuardMockAddress], [user1]))
                 .to.emit(safe, "ChangedModuleGuard")
@@ -609,7 +609,7 @@ describe("ModuleManager", () => {
 
             const invocationCountBefore = await validModuleGuardMock.invocationCount();
             const validModuleGuardMockAddress = await validModuleGuardMock.getAddress();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
 
             await executeContractCallWithSigners(safe, safe, "setModuleGuard", [validModuleGuardMockAddress], [user1]);
 

--- a/test/core/Safe.OwnerManager.spec.ts
+++ b/test/core/Safe.OwnerManager.spec.ts
@@ -11,7 +11,7 @@ describe("OwnerManager", () => {
         const signers = await ethers.getSigners();
         const [user1] = signers;
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             signers,
         };
     });

--- a/test/core/Safe.Signatures.spec.ts
+++ b/test/core/Safe.Signatures.spec.ts
@@ -24,7 +24,7 @@ describe("Safe", () => {
         const compatFallbackHandler = await getCompatFallbackHandler();
         const signers = await ethers.getSigners();
         const [user1] = signers;
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
 
         return {
             safe,
@@ -165,7 +165,7 @@ describe("Safe", () => {
             const {
                 signers: [user1],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             await expect(executeTx(safe, tx, [await safeSignTypedData(user1, safeAddress, tx, 1)])).to.be.revertedWith("GS026");
@@ -243,7 +243,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             await expect(executeTx(safe, tx, [])).to.be.revertedWith("GS020");
@@ -253,7 +253,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             await expect(
@@ -271,9 +271,15 @@ describe("Safe", () => {
             } = await setupTests();
             const compatFallbackHandler = await getCompatFallbackHandler();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const signerSafe = await getSafeWithOwners([user5.address], 1, ethers.ZeroAddress, "0x", compatFallbackHandlerAddress);
+            const signerSafe = await getSafeWithOwners({
+                owners: [user5.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const signerSafeAddress = await signerSafe.getAddress();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address, signerSafeAddress]);
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
 
@@ -363,7 +369,7 @@ describe("Safe", () => {
             const {
                 signers: [user1],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -397,7 +403,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -408,7 +414,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -426,9 +432,15 @@ describe("Safe", () => {
             } = await setupTests();
             const compatFallbackHandler = await getCompatFallbackHandler();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const signerSafe = await getSafeWithOwners([user5.address], 1, ethers.ZeroAddress, "0x", compatFallbackHandlerAddress);
+            const signerSafe = await getSafeWithOwners({
+                owners: [user5.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const signerSafeAddress = await signerSafe.getAddress();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address, signerSafeAddress]);
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -514,7 +526,7 @@ describe("Safe", () => {
             const {
                 signers: [user1],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
@@ -542,13 +554,11 @@ describe("Safe", () => {
                 compatFallbackHandler,
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address],
-                3,
-                ethers.ZeroAddress,
-                "0x",
-                await compatFallbackHandler.getAddress(),
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address],
+                threshold: 3,
+                fallbackHandler: await compatFallbackHandler.getAddress(),
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
@@ -561,13 +571,11 @@ describe("Safe", () => {
                 compatFallbackHandler,
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address],
-                3,
-                ethers.ZeroAddress,
-                "0x",
-                await compatFallbackHandler.getAddress(),
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address],
+                threshold: 3,
+                fallbackHandler: await compatFallbackHandler.getAddress(),
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHashData = preimageSafeTransactionHash(safeAddress, tx, await chainId());
@@ -586,15 +594,17 @@ describe("Safe", () => {
                 signers: [user1, user2, user3, user4, user5],
             } = await setupTests();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const signerSafe = await getSafeWithOwners([user5.address], 1, ethers.ZeroAddress, "0x", compatFallbackHandlerAddress);
+            const signerSafe = await getSafeWithOwners({
+                owners: [user5.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const signerSafeAddress = await signerSafe.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
-                5,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+                threshold: 5,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -715,7 +725,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -726,7 +736,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -746,9 +756,15 @@ describe("Safe", () => {
             } = await setupTests();
             const compatFallbackHandler = await getCompatFallbackHandler();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const signerSafe = await getSafeWithOwners([user5.address], 1, ethers.ZeroAddress, "0x", compatFallbackHandlerAddress);
+            const signerSafe = await getSafeWithOwners({
+                owners: [user5.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const signerSafeAddress = await signerSafe.getAddress();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address, signerSafeAddress]);
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -781,7 +797,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3, user4],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address, user4.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -794,7 +810,7 @@ describe("Safe", () => {
             const {
                 signers: [user1, user2, user3, user4],
             } = await setupTests();
-            const safe = await getSafeWithOwners([user1.address, user2.address, user3.address, user4.address], 2);
+            const safe = await getSafeWithOwners({ owners: [user1.address, user2.address, user3.address, user4.address], threshold: 2 });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -817,7 +833,7 @@ describe("Safe", () => {
                 signers: [user1, user2],
             } = await setupTests();
 
-            const safe = await getSafeWithOwners([user1.address]);
+            const safe = await getSafeWithOwners({ owners: [user1.address] });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -944,13 +960,11 @@ describe("Safe", () => {
                 signers: [user1, user2, user3],
             } = await setupTests();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address],
-                3,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address],
+                threshold: 3,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
 
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
@@ -964,13 +978,11 @@ describe("Safe", () => {
                 signers: [user1, user2, user3],
             } = await setupTests();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address],
-                3,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address],
+                threshold: 3,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
 
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
@@ -989,15 +1001,17 @@ describe("Safe", () => {
             } = await setupTests();
             const compatFallbackHandler = await getCompatFallbackHandler();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const signerSafe = await getSafeWithOwners([user5.address], 1, ethers.ZeroAddress, "0x", compatFallbackHandlerAddress);
+            const signerSafe = await getSafeWithOwners({
+                owners: [user5.address],
+                threshold: 1,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const signerSafeAddress = await signerSafe.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
-                5,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address, signerSafeAddress],
+                threshold: 5,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());
@@ -1032,13 +1046,11 @@ describe("Safe", () => {
                 signers: [user1, user2, user3, user4],
             } = await setupTests();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address, user4.address],
-                4,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address],
+                threshold: 4,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
 
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
@@ -1054,13 +1066,11 @@ describe("Safe", () => {
                 signers: [user1, user2, user3, user4],
             } = await setupTests();
             const compatFallbackHandlerAddress = await compatFallbackHandler.getAddress();
-            const safe = await getSafeWithOwners(
-                [user1.address, user2.address, user3.address, user4.address],
-                2,
-                ethers.ZeroAddress,
-                "0x",
-                compatFallbackHandlerAddress,
-            );
+            const safe = await getSafeWithOwners({
+                owners: [user1.address, user2.address, user3.address, user4.address],
+                threshold: 2,
+                fallbackHandler: compatFallbackHandlerAddress,
+            });
             const safeAddress = await safe.getAddress();
             const tx = buildSafeTransaction({ to: safeAddress, nonce: await safe.nonce() });
             const txHash = calculateSafeTransactionHash(safeAddress, tx, await chainId());

--- a/test/core/Safe.StorageAccessible.spec.ts
+++ b/test/core/Safe.StorageAccessible.spec.ts
@@ -9,7 +9,7 @@ describe("StorageAccessible", () => {
         const [user1, user2] = await ethers.getSigners();
         const killLib = await killLibContract(user1);
         return {
-            safe: await getSafeWithOwners([user1.address, user2.address], 1),
+            safe: await getSafeWithOwners({ owners: [user1.address, user2.address], threshold: 1 }),
             killLib,
         };
     });

--- a/test/factory/ProxyFactory.spec.ts
+++ b/test/factory/ProxyFactory.spec.ts
@@ -37,7 +37,7 @@ describe("ProxyFactory", () => {
         const [user1] = signers;
         const singleton = await deployContract(user1, SINGLETON_SOURCE);
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             factory: await getFactory(),
             mock: await getMock(),
             singleton,

--- a/test/guards/DebugTransactionGuard.spec.ts
+++ b/test/guards/DebugTransactionGuard.spec.ts
@@ -10,7 +10,7 @@ describe("DebugTransactionGuard", () => {
         await deployments.fixture();
         const signers = await ethers.getSigners();
         const [user1] = signers;
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
         const guardFactory = await hre.ethers.getContractFactory("DebugTransactionGuard");
         const guard = await guardFactory.deploy();
         const guardAddress = await guard.getAddress();

--- a/test/guards/DelegateCallTransactionGuard.spec.ts
+++ b/test/guards/DelegateCallTransactionGuard.spec.ts
@@ -10,7 +10,7 @@ describe("DelegateCallTransactionGuard", () => {
         await deployments.fixture();
         const signers = await ethers.getSigners();
         const [user1] = signers;
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
         const guardFactory = await hre.ethers.getContractFactory("DelegateCallTransactionGuard");
         const guard = await guardFactory.deploy(AddressZero);
         const guardAddress = await guard.getAddress();

--- a/test/guards/OnlyOwnersGuard.spec.ts
+++ b/test/guards/OnlyOwnersGuard.spec.ts
@@ -14,7 +14,7 @@ describe("OnlyOwnersGuard", () => {
         await deployments.fixture();
         const signers = await ethers.getSigners();
         const [user1] = signers;
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
         const guardFactory = await hre.ethers.getContractFactory("OnlyOwnersGuard");
         const guard = await guardFactory.deploy();
         const guardAddress = await guard.getAddress();

--- a/test/guards/ReentrancyTransactionGuard.spec.ts
+++ b/test/guards/ReentrancyTransactionGuard.spec.ts
@@ -15,7 +15,7 @@ describe("ReentrancyTransactionGuard", () => {
         await deployments.fixture();
         const signers = await ethers.getSigners();
         const [user1] = signers;
-        const safe = await getSafeWithOwners([user1.address]);
+        const safe = await getSafeWithOwners({ owners: [user1.address] });
         const guardFactory = await hre.ethers.getContractFactory("ReentrancyTransactionGuard");
         const guard = await guardFactory.deploy();
         const guardAddress = await guard.getAddress();

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -21,15 +21,13 @@ describe("CompatibilityFallbackHandler", () => {
         const handlerAddress = await handler.getAddress();
         const signers = await ethers.getSigners();
         const [user1, user2] = signers;
-        const signerSafe = await getSafeWithOwners([user1.address], 1, ethers.ZeroAddress, "0x", handlerAddress);
+        const signerSafe = await getSafeWithOwners({ owners: [user1.address], threshold: 1, fallbackHandler: handlerAddress });
         const signerSafeAddress = await signerSafe.getAddress();
-        const safe = await getSafeWithOwners(
-            [user1.address, user2.address, signerSafeAddress],
-            2,
-            ethers.ZeroAddress,
-            "0x",
-            handlerAddress,
-        );
+        const safe = await getSafeWithOwners({
+            owners: [user1.address, user2.address, signerSafeAddress],
+            threshold: 2,
+            fallbackHandler: handlerAddress,
+        });
         const safeAddress = await safe.getAddress();
         const validator = await getCompatFallbackHandler(safeAddress);
         const killLib = await killLibContract(user1);

--- a/test/integration/Safe.0xExploit.spec.ts
+++ b/test/integration/Safe.0xExploit.spec.ts
@@ -12,11 +12,15 @@ describe("Safe", () => {
         const handlerAddress = await handler.getAddress();
         const signers = await ethers.getSigners();
         const [user1, user2] = signers;
-        const ownerSafe = await getSafeWithOwners([user1.address, user2.address], 2, ethers.ZeroAddress, "0x", handlerAddress);
+        const ownerSafe = await getSafeWithOwners({
+            owners: [user1.address, user2.address],
+            threshold: 2,
+            fallbackHandler: handlerAddress,
+        });
         const ownerSafeAddress = await ownerSafe.getAddress();
         const messageHandler = await getCompatFallbackHandler(ownerSafeAddress);
         return {
-            safe: await getSafeWithOwners([ownerSafeAddress, user1.address], 1),
+            safe: await getSafeWithOwners({ owners: [ownerSafeAddress, user1.address], threshold: 1 }),
             ownerSafe,
             messageHandler,
             signers,

--- a/test/integration/Safe.ReservedAddresses.spec.ts
+++ b/test/integration/Safe.ReservedAddresses.spec.ts
@@ -8,7 +8,7 @@ describe("Safe - Reserved Addresses", () => {
         await deployments.fixture();
         const [user1] = await ethers.getSigners();
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
         };
     });
 

--- a/test/l2/Safe.Execution.spec.ts
+++ b/test/l2/Safe.Execution.spec.ts
@@ -23,7 +23,7 @@ describe("SafeL2", () => {
         await deployments.fixture();
         const mock = await getMock();
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             mock,
             signers,
         };

--- a/test/libraries/CreateCall.spec.ts
+++ b/test/libraries/CreateCall.spec.ts
@@ -22,7 +22,7 @@ describe("CreateCall", () => {
         const signers = await ethers.getSigners();
         const [user1] = signers;
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             createCall: await getCreateCall(),
             testContract,
             signers,

--- a/test/libraries/Migration.spec.ts
+++ b/test/libraries/Migration.spec.ts
@@ -24,7 +24,7 @@ describe("Migration", () => {
         return {
             singleton: await getSafeSingleton(),
             singleton120,
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             migration,
             signers,
         };

--- a/test/libraries/MultiSend.spec.ts
+++ b/test/libraries/MultiSend.spec.ts
@@ -30,7 +30,7 @@ describe("MultiSend", () => {
         const [user1] = signers;
         const storageSetter = await deployContract(user1, setterSource);
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             multiSend: await getMultiSend(),
             mock: await getMock(),
             delegateCaller: await getDelegateCaller(),

--- a/test/libraries/MultiSendCallOnly.spec.ts
+++ b/test/libraries/MultiSendCallOnly.spec.ts
@@ -30,7 +30,7 @@ describe("MultiSendCallOnly", () => {
         const [user1] = signers;
         const storageSetter = await deployContract(user1, setterSource);
         return {
-            safe: await getSafeWithOwners([user1.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address] }),
             multiSend: await getMultiSendCallOnly(),
             mock: await getMock(),
             delegateCaller: await getDelegateCaller(),

--- a/test/libraries/SafeToL2Setup.spec.ts
+++ b/test/libraries/SafeToL2Setup.spec.ts
@@ -121,7 +121,7 @@ describe("SafeToL2Setup", () => {
                     safeToL2SetupLib,
                     signers: [user1],
                 } = await setupTests();
-                const safe = await getSafeWithOwners([user1.address]);
+                const safe = await getSafeWithOwners({ owners: [user1.address] });
                 const safeToL2SetupLibAddress = await safeToL2SetupLib.getAddress();
 
                 await expect(

--- a/test/libraries/SignMessageLib.spec.ts
+++ b/test/libraries/SignMessageLib.spec.ts
@@ -11,7 +11,7 @@ describe("SignMessageLib", () => {
         const signers = await ethers.getSigners();
         const [user1, user2] = signers;
         return {
-            safe: await getSafeWithOwners([user1.address, user2.address]),
+            safe: await getSafeWithOwners({ owners: [user1.address, user2.address] }),
             lib,
             signers,
         };

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -7,6 +7,16 @@ import { safeContractUnderTest } from "./config";
 import { getRandomIntAsString } from "./numbers";
 import { Safe, SafeL2, SafeMigration } from "../../typechain-types";
 
+type safeWithFullConfig = {
+    readonly owners: string[];
+    threshold?: number;
+    to?: string;
+    data?: string;
+    fallbackHandler?: string;
+    logGasUsage?: boolean;
+    saltNumber?: string;
+};
+
 export const defaultTokenCallbackHandlerDeployment = async () => {
     return await deployments.get("TokenCallbackHandler");
 };
@@ -132,46 +142,30 @@ export const getSafeTemplate = async (saltNumber: string = getRandomIntAsString(
     return Safe.attach(template) as Safe | SafeL2;
 };
 
-export const getSafeWithOwners = async (
-    owners: string[],
-    threshold: number = owners.length,
-    to: string = AddressZero,
-    data: string = "0x",
-    fallbackHandler: string = AddressZero,
-    logGasUsage: boolean = false,
-    saltNumber: string = getRandomIntAsString(),
-) => {
-    const template = await getSafeTemplate(saltNumber);
+export const getSafeWithOwners = async (safe: safeWithFullConfig) => {
+    if (typeof safe.threshold === "undefined") safe.threshold = safe.owners.length;
+    if (typeof safe.to === "undefined") safe.to = AddressZero;
+    if (typeof safe.data === "undefined") safe.data = "0x";
+    if (typeof safe.fallbackHandler === "undefined") safe.fallbackHandler = AddressZero;
+    if (typeof safe.logGasUsage === "undefined") safe.logGasUsage = false;
+    if (typeof safe.saltNumber === "undefined") safe.saltNumber = getRandomIntAsString();
+
+    const template = await getSafeTemplate(safe.saltNumber);
     await logGas(
-        `Setup Safe with ${owners.length} owner(s)${fallbackHandler && fallbackHandler !== AddressZero ? " and fallback handler" : ""}`,
-        template.setup(owners, threshold, to, data, fallbackHandler, AddressZero, 0, AddressZero),
-        !logGasUsage,
+        `Setup Safe with ${safe.owners.length} owner(s)${safe.fallbackHandler && safe.fallbackHandler !== AddressZero ? " and fallback handler" : ""}`,
+        template.setup(safe.owners, safe.threshold, safe.to, safe.data, safe.fallbackHandler, AddressZero, 0, AddressZero),
+        !safe.logGasUsage,
     );
     return template;
 };
 
-export const getSafeWithSingleton = async (
-    singleton: Safe | SafeL2,
-    owners: string[],
-    threshold?: number,
-    fallbackHandler?: string,
-    saltNumber: string = getRandomIntAsString(),
-) => {
+export const getSafeWithSingleton = async (singleton: Safe | SafeL2, owners: string[], saltNumber: string = getRandomIntAsString()) => {
     const factory = await getFactory();
     const singletonAddress = await singleton.getAddress();
     const template = await factory.createProxyWithNonce.staticCall(singletonAddress, "0x", saltNumber);
     await factory.createProxyWithNonce(singletonAddress, "0x", saltNumber).then((tx: any) => tx.wait());
     const safeProxy = singleton.attach(template) as Safe | SafeL2;
-    await safeProxy.setup(
-        owners,
-        threshold || owners.length,
-        AddressZero,
-        "0x",
-        fallbackHandler || AddressZero,
-        AddressZero,
-        0,
-        AddressZero,
-    );
+    await safeProxy.setup(owners, owners.length, AddressZero, "0x", AddressZero, AddressZero, 0, AddressZero);
 
     return safeProxy;
 };


### PR DESCRIPTION
Fixes #780 

This PR uses the typescript `types` to pass the parameters to `getSafeWithOwners(...)` as objects. All the parameters are kept as `readonly` because it is not supposed to change within the function (though `optional` parameters are assigned default values during restructuring).

Bonus Point: Found that `getSafeWithSingleton(...)` didn't use the `threshold` and `fallbackHandler` parameters in the current codebase, thus removing them for now (please comment if it should be reverted).