### PR TITLE
`SafeToL2Setup` deployment script

### DIFF
--- a/src/deploy/deploy_libraries.ts
+++ b/src/deploy/deploy_libraries.ts
@@ -33,6 +33,13 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         log: true,
         deterministicDeployment: true,
     });
+
+    await deploy("SafeToL2Setup", {
+        from: deployer,
+        args: [],
+        log: true,
+        deterministicDeployment: true,
+    });
 };
 
 deploy.tags = ["libraries", "l2-suite", "main-suite"];


### PR DESCRIPTION
This PR adds the `SafeToL2Setup` deployment (already added in the `main` with #816) to the release branch for `v1.4.1`.