### PR TITLE
Bump Version to v1.4.1-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@safe-global/safe-contracts",
-    "version": "1.4.1-1",
+    "version": "1.4.1-2",
     "description": "Ethereum multisig contract",
     "homepage": "https://github.com/safe-global/safe-contracts/",
     "license": "LGPL-3.0",


### PR DESCRIPTION
In preparation for a v1.4.1-2 release with the new library contracts, bump the version in the `package.json` manifest file.