### PR TITLE
Tests job updated in Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
 
     tests:
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                contract-name: ["Safe", "SafeL2"]
-        env:
-            SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,24 @@ jobs:
                   cache: "npm"
             - run: npm ci
             - run: npm run build
+            - run: npm run test
+
+    coverage:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                contract-name: ["Safe", "SafeL2"]
+        env:
+            SAFE_CONTRACT_UNDER_TEST: ${{ matrix.contract-name }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: "npm"
+            - run: npm ci
+            - run: npm run build
             - run: npm run coverage
             - name: Send coverage to Coveralls (parallel)
               uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Previously we only checked coverage using `npm run coverage` which I believe only checked `hardhat test --network hardhat`, thus not checking the rest of the types of test based on L1, L2 and ZK. This adds another job in the CI which checks for the same.