### PR TITLE
fix: remove invalid documentation on execTransactionFromModule

### DIFF
--- a/contracts/interfaces/IModuleManager.sol
+++ b/contracts/interfaces/IModuleManager.sol
@@ -34,7 +34,6 @@ interface IModuleManager {
 
     /**
      * @notice Execute `operation` (0: Call, 1: DelegateCall) to `to` with `value` (Native Token)
-     * @dev Function is virtual to allow overriding for L2 singleton to emit an event for indexing.
      * @param to Destination address of module transaction.
      * @param value Ether value of module transaction.
      * @param data Data payload of module transaction.


### PR DESCRIPTION
While working on an indexer for module events, I noticed this comment is no longer valid as `SafeL2` now uses `onBeforeExecTransactionFromModule` to emit the `SafeModuleTransaction` event.