### PR TITLE
enable zksync tests again

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build:ts": "rimraf dist && tsc -p tsconfig.prod.json",
         "build:ts:dev": "rimraf dist && tsc -p tsconfig.json",
         "test:zk": "HARDHAT_ENABLE_ZKSYNC=1 hardhat test",
-        "test": "hardhat test --network hardhat && npm run test:L1 && npm run test:L2",
+        "test": "hardhat test --network hardhat && npm run test:L1 && npm run test:L2 && npm run test:zk",
         "test:parallel": "hardhat test --parallel",
         "test:L1": "HARDHAT_CHAIN_ID=1 hardhat test --grep '@L1'",
         "test:L2": "SAFE_CONTRACT_UNDER_TEST=SafeL2 hardhat test --network hardhat",


### PR DESCRIPTION
This pull request includes a small but significant change to the `package.json` file to enhance the testing process.

Enhancements to testing:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L22-R22): Modified the `test` script to include running `test:zk` to ensure zkSync tests are executed along with other tests.