### PR TITLE
Disable Pre-approved IsValidSignature

### DIFF
--- a/certora/specs/NativeTokenRefund.spec
+++ b/certora/specs/NativeTokenRefund.spec
@@ -1,7 +1,7 @@
 // This spec is a separate file because we summarize checkSignatures here
 
 methods {
-    function checkSignatures(bytes32, bytes memory) internal => NONDET;
+    function checkSignatures(address, bytes32, bytes memory) internal => NONDET;
 
     function getNativeTokenBalanceFor(address) external returns (uint256) envfree;
     function getSafeGuard() external returns (address) envfree;

--- a/certora/specs/Safe.spec
+++ b/certora/specs/Safe.spec
@@ -18,7 +18,7 @@ methods {
     function execTransactionFromModule(address,uint256,bytes,Enum.Operation) external returns (bool);
     function execTransaction(address,uint256,bytes,Enum.Operation,uint256,uint256,uint256,address,address,bytes) external returns (bool);
 
-    function checkSignatures(bytes32, bytes memory) internal => NONDET;
+    function checkSignatures(address, bytes32, bytes memory) internal => NONDET;
 }
 
 definition reachableOnly(method f) returns bool =

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -335,7 +335,8 @@ contract Safe is
      * @notice Checks whether the signature provided is valid for the provided hash. Reverts otherwise.
      *         The `data` parameter is completely ignored during signature verification.
      * @dev This function is provided for compatibility with previous versions.
-     *      Use `checkSignatures(bytes32,bytes)` instead.
+     *      Use `checkSignatures(address,bytes32,bytes)` instead.
+     *      ⚠️⚠️⚠️ If the caller is an owner of the Safe, it can trivially sign any hash with a pre-approve signature and may reduce the threshold of the signature by 1. ⚠️⚠️⚠️
      * @param dataHash Hash of the data (could be either a message hash or transaction hash).
      * @param data **IGNORED** The data pre-image.
      * @param signatures Signature data that should be verified.
@@ -351,6 +352,7 @@ contract Safe is
      *         The `data` parameter is completely ignored during signature verification.
      * @dev This function is provided for compatibility with previous versions.
      *      Use `checkNSignatures(address,bytes32,bytes,uint256)` instead.
+     *      ⚠️⚠️⚠️ If the caller is an owner of the Safe, it can trivially sign any hash with a pre-approve signature and may reduce the threshold of the signature by 1. ⚠️⚠️⚠️
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param data **IGNORED** The data pre-image.
      * @param signatures Signature data that should be verified.

--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -139,7 +139,7 @@ contract Safe is
                 // We use the post-increment here, so the current nonce value is used and incremented afterwards.
                 nonce++
             );
-            checkSignatures(txHash, signatures);
+            checkSignatures(msg.sender, txHash, signatures);
         }
         address guard = getGuard();
         {
@@ -267,12 +267,12 @@ contract Safe is
     /**
      * @inheritdoc ISafe
      */
-    function checkSignatures(bytes32 dataHash, bytes memory signatures) public view override {
+    function checkSignatures(address executor, bytes32 dataHash, bytes memory signatures) public view override {
         // Load threshold to avoid multiple storage loads
         uint256 _threshold = threshold;
         // Check that a threshold is set
         if (_threshold == 0) revertWithError("GS001");
-        checkNSignatures(msg.sender, dataHash, signatures, _threshold);
+        checkNSignatures(executor, dataHash, signatures, _threshold);
     }
 
     /**
@@ -343,7 +343,7 @@ contract Safe is
      */
     function checkSignatures(bytes32 dataHash, bytes calldata data, bytes memory signatures) external view {
         data;
-        checkSignatures(dataHash, signatures);
+        checkSignatures(msg.sender, dataHash, signatures);
     }
 
     /**

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -62,8 +62,8 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         if (_signature.length == 0) {
             require(safe.signedMessages(messageHash) != 0, "Hash not approved");
         } else {
-            // We explicitly do not allow caller approved sigantures for EIP-1271. This is done by setting the executor
-            // address to `0` which can never be an owner of the Safe.
+            // We explicitly do not allow caller approved signatures for EIP-1271 to prevent unexpected behaviour. This
+            // is done by setting the executor address to `0` which can never be an owner of the Safe.
             safe.checkSignatures(address(0), messageHash, _signature);
         }
         return EIP1271_MAGIC_VALUE;

--- a/contracts/handler/CompatibilityFallbackHandler.sol
+++ b/contracts/handler/CompatibilityFallbackHandler.sol
@@ -62,7 +62,9 @@ contract CompatibilityFallbackHandler is TokenCallbackHandler, ISignatureValidat
         if (_signature.length == 0) {
             require(safe.signedMessages(messageHash) != 0, "Hash not approved");
         } else {
-            safe.checkSignatures(messageHash, _signature);
+            // We explicitly do not allow caller approved sigantures for EIP-1271. This is done by setting the executor
+            // address to `0` which can never be an owner of the Safe.
+            safe.checkSignatures(address(0), messageHash, _signature);
         }
         return EIP1271_MAGIC_VALUE;
     }

--- a/contracts/handler/extensible/ERC165Handler.sol
+++ b/contracts/handler/extensible/ERC165Handler.sol
@@ -2,10 +2,10 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import {IERC165} from "../../interfaces/IERC165.sol";
-import {Safe, MarshalLib, ExtensibleBase} from "./ExtensibleBase.sol";
+import {ISafe, MarshalLib, ExtensibleBase} from "./ExtensibleBase.sol";
 
 interface IERC165Handler {
-    function safeInterfaces(Safe safe, bytes4 interfaceId) external view returns (bool);
+    function safeInterfaces(ISafe safe, bytes4 interfaceId) external view returns (bool);
 
     function setSupportedInterface(bytes4 interfaceId, bool supported) external;
 
@@ -17,12 +17,12 @@ interface IERC165Handler {
 abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
     // --- events ---
 
-    event AddedInterface(Safe indexed safe, bytes4 interfaceId);
-    event RemovedInterface(Safe indexed safe, bytes4 interfaceId);
+    event AddedInterface(ISafe indexed safe, bytes4 interfaceId);
+    event RemovedInterface(ISafe indexed safe, bytes4 interfaceId);
 
     // --- storage ---
 
-    mapping(Safe => mapping(bytes4 => bool)) public override safeInterfaces;
+    mapping(ISafe => mapping(bytes4 => bool)) public override safeInterfaces;
 
     // --- setters ---
 
@@ -32,7 +32,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
      * @param supported True if the interface is supported, false otherwise
      */
     function setSupportedInterface(bytes4 interfaceId, bool supported) public override onlySelf {
-        Safe safe = Safe(payable(_manager()));
+        ISafe safe = ISafe(payable(_manager()));
         // invalid interface id per ERC165 spec
         require(interfaceId != 0xffffffff, "invalid interface id");
         bool current = safeInterfaces[safe][interfaceId];
@@ -51,7 +51,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
      * @param handlerWithSelectors The handlers encoded with the 4-byte selectors of the methods
      */
     function addSupportedInterfaceBatch(bytes4 _interfaceId, bytes32[] calldata handlerWithSelectors) external override onlySelf {
-        Safe safe = Safe(payable(_msgSender()));
+        ISafe safe = ISafe(payable(_msgSender()));
         bytes4 interfaceId;
         for (uint256 i = 0; i < handlerWithSelectors.length; i++) {
             (bool isStatic, bytes4 selector, address handlerAddress) = MarshalLib.decodeWithSelector(handlerWithSelectors[i]);
@@ -73,7 +73,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
      * @param selectors The selectors of the methods to remove
      */
     function removeSupportedInterfaceBatch(bytes4 _interfaceId, bytes4[] calldata selectors) external override onlySelf {
-        Safe safe = Safe(payable(_msgSender()));
+        ISafe safe = ISafe(payable(_msgSender()));
         bytes4 interfaceId;
         for (uint256 i = 0; i < selectors.length; i++) {
             _setSafeMethod(safe, selectors[i], bytes32(0));
@@ -99,7 +99,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC165Handler).interfaceId ||
             _supportsInterface(interfaceId) ||
-            safeInterfaces[Safe(payable(_manager()))][interfaceId];
+            safeInterfaces[ISafe(payable(_manager()))][interfaceId];
     }
 
     // --- internal ---

--- a/contracts/handler/extensible/ExtensibleBase.sol
+++ b/contracts/handler/extensible/ExtensibleBase.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import {Safe} from "../../Safe.sol";
+import {ISafe} from "../../interfaces/ISafe.sol";
 import {HandlerContext} from "../HandlerContext.sol";
 import {MarshalLib} from "./MarshalLib.sol";
 
 interface IFallbackMethod {
-    function handle(Safe safe, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
+    function handle(ISafe safe, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
 }
 
 interface IStaticFallbackMethod {
-    function handle(Safe safe, address sender, uint256 value, bytes calldata data) external view returns (bytes memory result);
+    function handle(ISafe safe, address sender, uint256 value, bytes calldata data) external view returns (bytes memory result);
 }
 
 /**
@@ -20,9 +20,9 @@ interface IStaticFallbackMethod {
  */
 abstract contract ExtensibleBase is HandlerContext {
     // --- events ---
-    event AddedSafeMethod(Safe indexed safe, bytes4 selector, bytes32 method);
-    event ChangedSafeMethod(Safe indexed safe, bytes4 selector, bytes32 oldMethod, bytes32 newMethod);
-    event RemovedSafeMethod(Safe indexed safe, bytes4 selector);
+    event AddedSafeMethod(ISafe indexed safe, bytes4 selector, bytes32 method);
+    event ChangedSafeMethod(ISafe indexed safe, bytes4 selector, bytes32 oldMethod, bytes32 newMethod);
+    event RemovedSafeMethod(ISafe indexed safe, bytes4 selector);
 
     // --- storage ---
 
@@ -31,7 +31,7 @@ abstract contract ExtensibleBase is HandlerContext {
     // - The first byte is 0x00 if the method is static and 0x01 if the method is not static
     // - The last 20 bytes are the address of the handler contract
     // The method is encoded / decoded using the MarshalLib
-    mapping(Safe => mapping(bytes4 => bytes32)) public safeMethods;
+    mapping(ISafe => mapping(bytes4 => bytes32)) public safeMethods;
 
     // --- modifiers ---
     modifier onlySelf() {
@@ -44,7 +44,7 @@ abstract contract ExtensibleBase is HandlerContext {
 
     // --- internal ---
 
-    function _setSafeMethod(Safe safe, bytes4 selector, bytes32 newMethod) internal {
+    function _setSafeMethod(ISafe safe, bytes4 selector, bytes32 newMethod) internal {
         (, address newHandler) = MarshalLib.decode(newMethod);
         bytes32 oldMethod = safeMethods[safe][selector];
         (, address oldHandler) = MarshalLib.decode(oldMethod);
@@ -67,8 +67,8 @@ abstract contract ExtensibleBase is HandlerContext {
      * @return safe The safe whose FallbackManager is making this call
      * @return sender The original `msg.sender` (as received by the FallbackManager)
      */
-    function _getContext() internal view returns (Safe safe, address sender) {
-        safe = Safe(payable(_manager()));
+    function _getContext() internal view returns (ISafe safe, address sender) {
+        safe = ISafe(payable(_manager()));
         sender = _msgSender();
     }
 
@@ -79,7 +79,7 @@ abstract contract ExtensibleBase is HandlerContext {
      * @return isStatic Whether the method is static (`view`) or not
      * @return handler the address of the handler contract
      */
-    function _getContextAndHandler() internal view returns (Safe safe, address sender, bool isStatic, address handler) {
+    function _getContextAndHandler() internal view returns (ISafe safe, address sender, bool isStatic, address handler) {
         (safe, sender) = _getContext();
         (isStatic, handler) = MarshalLib.decode(safeMethods[safe][msg.sig]);
     }

--- a/contracts/handler/extensible/FallbackHandler.sol
+++ b/contracts/handler/extensible/FallbackHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import {Safe, IStaticFallbackMethod, IFallbackMethod, ExtensibleBase} from "./ExtensibleBase.sol";
+import {ISafe, IStaticFallbackMethod, IFallbackMethod, ExtensibleBase} from "./ExtensibleBase.sol";
 
 interface IFallbackHandler {
     function setSafeMethod(bytes4 selector, bytes32 newMethod) external;
@@ -22,7 +22,7 @@ abstract contract FallbackHandler is ExtensibleBase, IFallbackHandler {
      * @param newMethod A contract that implements the `IFallbackMethod` or `IStaticFallbackMethod` interface
      */
     function setSafeMethod(bytes4 selector, bytes32 newMethod) public override onlySelf {
-        _setSafeMethod(Safe(payable(_msgSender())), selector, newMethod);
+        _setSafeMethod(ISafe(payable(_msgSender())), selector, newMethod);
     }
 
     // --- fallback ---
@@ -30,7 +30,7 @@ abstract contract FallbackHandler is ExtensibleBase, IFallbackHandler {
     // solhint-disable-next-line
     fallback(bytes calldata) external returns (bytes memory result) {
         require(msg.data.length >= 24, "invalid method selector");
-        (Safe safe, address sender, bool isStatic, address handler) = _getContextAndHandler();
+        (ISafe safe, address sender, bool isStatic, address handler) = _getContextAndHandler();
         require(handler != address(0), "method handler not set");
 
         if (isStatic) {

--- a/contracts/interfaces/ISafe.sol
+++ b/contracts/interfaces/ISafe.sol
@@ -76,12 +76,15 @@ interface ISafe is IModuleManager, IGuardManager, IOwnerManager, IFallbackManage
     ) external payable returns (bool success);
 
     /**
-     * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
+     * @notice Checks whether the signature provided is valid for the provided data and hash and executor. Reverts otherwise.
+     * @param executor Address that executes the transaction.
+     *        ⚠️⚠️⚠️ Make sure that the executor address is a legitimate executor.
+     *        Incorrectly passed the executor might reduce the threshold by 1 signature. ⚠️⚠️⚠️
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
      * @param signatures Signature data that should be verified.
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      */
-    function checkSignatures(bytes32 dataHash, bytes memory signatures) external view;
+    function checkSignatures(address executor, bytes32 dataHash, bytes memory signatures) external view;
 
     /**
      * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.

--- a/contracts/test/TestSafeSignatureVerifier.sol
+++ b/contracts/test/TestSafeSignatureVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import {Safe, EIP712, ISafeSignatureVerifier} from "../handler/extensible/SignatureVerifierMuxer.sol";
+import {ISafe, EIP712, ISafeSignatureVerifier} from "../handler/extensible/SignatureVerifierMuxer.sol";
 
 /**
  * @title TestSafeSignatureVerifier - A simple test contract that implements the ISafeSignatureVerifier interface
@@ -16,7 +16,7 @@ contract TestSafeSignatureVerifier is ISafeSignatureVerifier {
      * @return magic The magic value that should be returned if the signature is valid (0x1626ba7e)
      */
     function isValidSafeSignature(
-        Safe,
+        ISafe,
         address,
         bytes32 _hash,
         bytes32 domainSeparator,

--- a/test/handlers/CompatibilityFallbackHandler.spec.ts
+++ b/test/handlers/CompatibilityFallbackHandler.spec.ts
@@ -124,9 +124,37 @@ describe("CompatibilityFallbackHandler", () => {
 
             const signerSafeSig = buildContractSignature(signerSafeAddress, signerSafeOwnerSignature.data);
 
-            expect(
-                await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes([typedDataSig, ethSignSig, signerSafeSig])),
-            ).to.be.eq("0x1626ba7e");
+            for (const signatures of [
+                [typedDataSig, ethSignSig],
+                [typedDataSig, signerSafeSig],
+                [ethSignSig, signerSafeSig],
+            ]) {
+                expect(await validator.isValidSignature.staticCall(dataHash, buildSignatureBytes(signatures))).to.be.eq("0x1626ba7e");
+            }
+        });
+
+        it("should not accept pre-approved signatures", async () => {
+            const {
+                validator,
+                signers: [user1, user2],
+            } = await setupTests();
+            const validatorAddress = await validator.getAddress();
+            const dataHash = ethers.keccak256("0xbaddad");
+            const user1Signature = {
+                signer: user1.address,
+                data: ethers.solidityPacked(["uint256", "uint256", "uint8"], [user1.address, 0, 1]),
+            };
+            const user2Signature = {
+                signer: user2.address,
+                data: await user2.signTypedData(
+                    { verifyingContract: validatorAddress, chainId: await chainId() },
+                    EIP712_SAFE_MESSAGE_TYPE,
+                    { message: dataHash },
+                ),
+            };
+
+            const signatures = buildSignatureBytes([user1Signature, user2Signature]);
+            await expect(validator.connect(user1).isValidSignature.staticCall(dataHash, signatures)).to.be.reverted;
         });
     });
 


### PR DESCRIPTION
This commit disables support for pre-approved signatures from `msg.sender` for `isValidSignature` calls.

Note that we remove the new 1.5.0-only `checkSignatures` interface in favour of one with `executor` explicitly provided to avoid issues for contracts that make use of this function.