### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ about: Bug report about the Safe smart contracts
 
 ## Description
 
-Please describe considely the bug you have found, and what you expect instead.
+Please describe concisely the bug you have found, and what you expect instead.
 
 ## Environment
 

--- a/docs/safe_tx_gas.md
+++ b/docs/safe_tx_gas.md
@@ -30,7 +30,7 @@ If `gasPrice` is set to `0` then the Safe Smart Account will **not** issue a ref
 
 Therefore it is not necessary to be as strict on the gas being passed along with the execution of the Safe transaction. As no refund is triggered the Safe will not pay for the execution costs, based on this the Safe Smart Account will send along all available case when no refund is used.
 
-Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](hhttps://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
+Before the execution the Safe Smart Account always check if enough gas is available to satisfy the `safeTxGas`. This can be seen in [`Safe.sol`](https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L168-L170):
 
 ```js
 require(gasleft() >=


### PR DESCRIPTION
Corrected `considely` to `concisely`
Corrected `hhttps` to `https`