### PR TITLE
typo fix proxies.ts

### DIFF
--- a/src/utils/proxies.ts
+++ b/src/utils/proxies.ts
@@ -26,7 +26,7 @@ export const getZkSyncBytecodeHashFromDeployerCallHeader = (proxyCreationCode: s
 export const calculateProxyAddress = async (
     factory: SafeProxyFactory,
     singleton: string,
-    inititalizer: string,
+    initializer: string,
     nonce: number | string,
     zkSync: boolean = false,
 ) => {


### PR DESCRIPTION
### Pull Request Title:
Fix Typo in `proxies.ts` - `inititalizer` to `initializer`

### Description:
This pull request corrects a typo in the `proxies.ts` file. The word `inititalizer` is corrected to `initializer`.

### Changes:
- Fixed the typo `inititalizer` to `initializer` in `proxies.ts`.

### Checklist:
- [x] Typo fixed and changes reviewed.
- [x] Code tested (if applicable).
- [x] Pull request description completed.

### Additional Notes:
This change is purely a typo fix and does not affect the functionality of the code.
