### PR TITLE
typo fix Safe.Execution.spec.ts

### DIFF
--- a/test/core/Safe.Execution.spec.ts
+++ b/test/core/Safe.Execution.spec.ts
@@ -271,7 +271,7 @@ describe("Safe", () => {
             if (hre.network.zksync) {
                 // This test fails in zksync because of (allegedly) enormous gas cost differences
                 // a call to useGas(8) costs ~400k gas in evm but ~28m gas in zksync.
-                // I suspect the gas cost difference to play a role but the zksync docs do not mention any numbers so i cant confirm this:
+                // I suspect the gas cost difference to play a role but the zksync docs do not mention any numbers so i can't confirm this:
                 // https://docs.zksync.io/zk-stack/concepts/fee-mechanism
                 // From zkSync team:
                 // Update: in-memory node when in standalone mode assumes very high l1 gas price resulting in a very high gas consumption,


### PR DESCRIPTION
## Typo Fix in `Safe.Execution.spec.ts`

This pull request fixes a typographical error in the `Safe.Execution.spec.ts` file. The comment about gas cost differences in zkSync was incorrectly written as "i cant confirm this," which has now been corrected to "i can't confirm this."

### Changes:
- Corrected the typo from "i cant confirm this" to "i can't confirm this" in the test comment.

### Checklist:
- [x] Fixed typographical error in the comment.
- [x] Changes reviewed and tested.
