### PR TITLE
[Certora Audit] I-02. Some comments say `keccak` instead of `keccak256`

### DIFF
--- a/contracts/common/SecuredTokenTransfer.sol
+++ b/contracts/common/SecuredTokenTransfer.sol
@@ -16,7 +16,7 @@ abstract contract SecuredTokenTransfer {
      * @return transferred Returns true if the transfer was successful
      */
     function transferToken(address token, address receiver, uint256 amount) internal returns (bool transferred) {
-        // 0xa9059cbb - keccak("transfer(address,uint256)")
+        // 0xa9059cbb - bytes4(keccak256("transfer(address,uint256)"))
         bytes memory data = abi.encodeWithSelector(0xa9059cbb, receiver, amount);
         /* solhint-disable no-inline-assembly */
         /// @solidity memory-safe-assembly

--- a/contracts/proxies/SafeProxy.sol
+++ b/contracts/proxies/SafeProxy.sol
@@ -38,7 +38,7 @@ contract SafeProxy {
         /* solhint-disable no-inline-assembly */
         assembly {
             let _singleton := sload(0)
-            // 0xa619486e == keccak("masterCopy()"). The value is right padded to 32-bytes with 0s
+            // 0xa619486e == bytes4(keccak256("masterCopy()")). The value is right padded to 32-bytes with 0s
             if eq(calldataload(0), 0xa619486e00000000000000000000000000000000000000000000000000000000) {
                 // We mask the singleton address when handling the `masterCopy()` call to ensure that it is correctly
                 // ABI-encoded. We do this by shifting the address left by 96 bits (or 12 bytes) and then storing it in


### PR DESCRIPTION
This pull request includes updates to comments in the Solidity smart contracts to clarify the usage of the `keccak256` function. The changes ensure that the comments accurately reflect the encoding process used in the contracts.

Changes to comments for clarity:

* [`contracts/common/SecuredTokenTransfer.sol`](diffhunk://#diff-7a34930a339acfe3b45e163bee3e08df2132c01826e6e03771827a4181c6f567L19-R19): Updated the comment to specify that `0xa9059cbb` is the `bytes4` encoding of `keccak256("transfer(address,uint256)")`.
* [`contracts/proxies/SafeProxy.sol`](diffhunk://#diff-754f853ea53666aa85b2d27bbcc0623b7cfd83449e0b949eed39dde8f01ba1cdL41-R41): Updated the comment to specify that `0xa619486e` is the `bytes4` encoding of `keccak256("masterCopy()")`.