### PR TITLE
[Certora Audit] G-02. `OwnerManager.changeThreshold()` event update

### DIFF
--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -110,7 +110,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         // There has to be at least one Safe owner.
         if (_threshold == 0) revertWithError("GS202");
         threshold = _threshold;
-        emit ChangedThreshold(threshold);
+        emit ChangedThreshold(_threshold);
     }
 
     /**


### PR DESCRIPTION
This pull request includes a change which allows 1 SLOAD to be saved by emitting an existing memory variable instead of reading from storage.

* [`contracts/base/OwnerManager.sol`](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L113-R113): Modified the `emit` statement in the `setThreshold` function to use the `_threshold` parameter instead of `threshold`, ensuring the value from memory is emitted.