### PR TITLE
[Certora Audit] G-04. `ExtensibleBase._setSafeMethod()`: storage access optimization

### DIFF
--- a/contracts/handler/extensible/ExtensibleBase.sol
+++ b/contracts/handler/extensible/ExtensibleBase.sol
@@ -46,14 +46,15 @@ abstract contract ExtensibleBase is HandlerContext {
 
     function _setSafeMethod(ISafe safe, bytes4 selector, bytes32 newMethod) internal {
         (, address newHandler) = MarshalLib.decode(newMethod);
-        bytes32 oldMethod = safeMethods[safe][selector];
+        mapping(bytes4 => bytes32) storage safeMethod = safeMethods[safe];
+        bytes32 oldMethod = safeMethod[selector];
         (, address oldHandler) = MarshalLib.decode(oldMethod);
 
         if (address(newHandler) == address(0) && address(oldHandler) != address(0)) {
-            delete safeMethods[safe][selector];
+            delete safeMethod[selector];
             emit RemovedSafeMethod(safe, selector);
         } else {
-            safeMethods[safe][selector] = newMethod;
+            safeMethod[selector] = newMethod;
             if (address(oldHandler) == address(0)) {
                 emit AddedSafeMethod(safe, selector, newMethod);
             } else {


### PR DESCRIPTION
This pull request includes a refactor to the `_setSafeMethod` function in the `ExtensibleBase` contract to improve memory access.

The following optimizes the logic and minimizes storage accesses:

* [`contracts/handler/extensible/ExtensibleBase.sol`](diffhunk://#diff-e395e05c7e2951461c2e599137367a6a3304e849f3c522903d74f1a50f23b577L49-R57): Modified the `_setSafeMethod` function to use a local variable `safeMethod` for accessing the `safeMethods` mapping, which simplifies and clarifies the code.