### PR TITLE
[Certora Audit] G-05. Use `iszero` instead of `eq(*, 0)`

### DIFF
--- a/contracts/proxies/SafeProxyFactory.sol
+++ b/contracts/proxies/SafeProxyFactory.sol
@@ -40,7 +40,7 @@ contract SafeProxyFactory {
             /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
-                if eq(call(gas(), proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0), 0) {
+                if iszero(call(gas(), proxy, 0, add(initializer, 0x20), mload(initializer), 0, 0)) {
                     revert(0, 0)
                 }
             }


### PR DESCRIPTION
This pull request includes a critical update to the `SafeProxyFactory` contract in the `contracts/proxies/SafeProxyFactory.sol` file. The change improves the gas cost of the assembly code by replacing the `eq` function with the `iszero` function.

Key change:

* [`contracts/proxies/SafeProxyFactory.sol`](diffhunk://#diff-53aac98a01e16743466b00bdcb233208f95e1113cc90b95181187d9862b4ad6eL43-R43): Replaced the `eq` function with the `iszero` function in the assembly block to improve code readability and reliability.