### PR TITLE
[Certora Audit] G-06. `ExtensibleFallbackHandler._supportsInterface()`: save gas via short-circuit evaluation

### DIFF
--- a/contracts/handler/ExtensibleFallbackHandler.sol
+++ b/contracts/handler/ExtensibleFallbackHandler.sol
@@ -18,11 +18,11 @@ contract ExtensibleFallbackHandler is FallbackHandler, SignatureVerifierMuxer, T
      */
     function _supportsInterface(bytes4 interfaceId) internal pure override returns (bool) {
         return
+            interfaceId == type(ERC721TokenReceiver).interfaceId ||
+            interfaceId == type(ERC1155TokenReceiver).interfaceId ||
             interfaceId == type(ERC1271).interfaceId ||
             interfaceId == type(ISignatureVerifierMuxer).interfaceId ||
             interfaceId == type(ERC165Handler).interfaceId ||
-            interfaceId == type(IFallbackHandler).interfaceId ||
-            interfaceId == type(ERC721TokenReceiver).interfaceId ||
-            interfaceId == type(ERC1155TokenReceiver).interfaceId;
+            interfaceId == type(IFallbackHandler).interfaceId;
     }
 }


### PR DESCRIPTION
This pull request includes a change to the `ExtensibleFallbackHandler` contract in the `contracts/handler/ExtensibleFallbackHandler.sol` file. The change modifies the `_supportsInterface` function to reorder the interface checks for `ERC721TokenReceiver`, `ERC1155TokenReceiver`, and `IFallbackHandler`. This helps in taking advantage of the short-circuit evaluation.

Changes to interface support order:

* [`contracts/handler/ExtensibleFallbackHandler.sol`](diffhunk://#diff-aa345618c4d3f173b09e211d0bd0eec0747177aab345bf8b9f5bbc874a765fe3R21-R26): Reordered the interface checks in the `_supportsInterface` function to place `ERC721TokenReceiver` and `ERC1155TokenReceiver` before `IFallbackHandler`.