### PR TITLE
[Certora Audit] G07. Use a mask instead of shifting left and right

### DIFF
--- a/contracts/handler/extensible/MarshalLib.sol
+++ b/contracts/handler/extensible/MarshalLib.sol
@@ -38,7 +38,7 @@ library MarshalLib {
         assembly {
             // set isStatic to true if the left-most byte of the data is 0x00
             isStatic := iszero(shr(248, data))
-            handler := shr(96, shl(96, data))
+            handler := and(data, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
         }
         /* solhint-enable no-inline-assembly */
     }
@@ -56,7 +56,7 @@ library MarshalLib {
         assembly {
             // set isStatic to true if the left-most byte of the data is 0x00
             isStatic := iszero(shr(248, data))
-            handler := shr(96, shl(96, data))
+            handler := and(data, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
             selector := shl(168, shr(160, data))
         }
         /* solhint-enable no-inline-assembly */

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -110,7 +110,7 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
             /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
-                sigSelector := and(calldataload(signature.offset), 0xFFFFFFFF)
+                sigSelector := and(calldataload(signature.offset), 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000)
             }
             /* solhint-enable no-inline-assembly */
 

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -110,7 +110,7 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
             /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
-                sigSelector := shl(224, shr(224, calldataload(signature.offset)))
+                sigSelector := and(calldataload(signature.offset), 0xFFFFFFFF)
             }
             /* solhint-enable no-inline-assembly */
 

--- a/contracts/handler/extensible/SignatureVerifierMuxer.sol
+++ b/contracts/handler/extensible/SignatureVerifierMuxer.sol
@@ -110,7 +110,7 @@ abstract contract SignatureVerifierMuxer is ExtensibleBase, ERC1271, ISignatureV
             /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {
-                sigSelector := and(calldataload(signature.offset), 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000)
+                sigSelector := calldataload(signature.offset)
             }
             /* solhint-enable no-inline-assembly */
 


### PR DESCRIPTION
This pull request includes changes to the `contracts/handler/extensible` directory, specifically in the `MarshalLib.sol` and `SignatureVerifierMuxer.sol` files. The changes focus on improving the handling of data and selectors within assembly code blocks to decrease gas usage.

Improvements to data handling and selector extraction:

* [`contracts/handler/extensible/MarshalLib.sol`](diffhunk://#diff-7122c44132b6fc89cd7c9f3c48519c88aaf7308705a1170d307d72465eb9e1c9L41-R41): Modified the way the `handler` is extracted from `data` by using a bitwise AND operation to ensure proper extraction of the handler address. [[1]](diffhunk://#diff-7122c44132b6fc89cd7c9f3c48519c88aaf7308705a1170d307d72465eb9e1c9L41-R41) [[2]](diffhunk://#diff-7122c44132b6fc89cd7c9f3c48519c88aaf7308705a1170d307d72465eb9e1c9L59-R59)
* [`contracts/handler/extensible/SignatureVerifierMuxer.sol`](diffhunk://#diff-62f21ce8850527f34ef2acdacd96d4a2a1150e3e2a7e16457e82236bbd4259d2L113-R113): Changed the extraction of `sigSelector` from `calldataload` to use a bitwise AND operation for more accurate and secure selector extraction.