### PR TITLE
[Certora Audit] G-10. ++i costs less gas compared to i++ or i+=1

### DIFF
--- a/contracts/Safe.sol
+++ b/contracts/Safe.sol
@@ -293,7 +293,7 @@ contract Safe is
         bytes32 r;
         bytes32 s;
         uint256 i;
-        for (i = 0; i < requiredSignatures; i++) {
+        for (i = 0; i < requiredSignatures; ++i) {
             (v, r, s) = signatureSplit(signatures, i);
             if (v == 0) {
                 // If v is 0 then it is a contract signature

--- a/contracts/base/ModuleManager.sol
+++ b/contracts/base/ModuleManager.sol
@@ -212,7 +212,7 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         while (next != address(0) && next != SENTINEL_MODULES && moduleCount < pageSize) {
             array[moduleCount] = next;
             next = modules[next];
-            moduleCount++;
+            ++moduleCount;
         }
 
         /**

--- a/contracts/base/OwnerManager.sol
+++ b/contracts/base/OwnerManager.sol
@@ -35,7 +35,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         if (_threshold == 0) revertWithError("GS202");
         // Initializing Safe owners.
         address currentOwner = SENTINEL_OWNERS;
-        for (uint256 i = 0; i < _owners.length; i++) {
+        for (uint256 i = 0; i < _owners.length; ++i) {
             // Owner address cannot be null.
             address owner = _owners[i];
             if (owner == address(0) || owner == SENTINEL_OWNERS || owner == address(this) || currentOwner == owner)
@@ -60,7 +60,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         if (owners[owner] != address(0)) revertWithError("GS204");
         owners[owner] = owners[SENTINEL_OWNERS];
         owners[SENTINEL_OWNERS] = owner;
-        ownerCount++;
+        ++ownerCount;
         emit AddedOwner(owner);
         // Change threshold if threshold was changed.
         if (threshold != _threshold) changeThreshold(_threshold);
@@ -77,7 +77,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         if (owners[prevOwner] != owner) revertWithError("GS205");
         owners[prevOwner] = owners[owner];
         owners[owner] = address(0);
-        ownerCount--;
+        --ownerCount;
         emit RemovedOwner(owner);
         // Change threshold if threshold was changed.
         if (threshold != _threshold) changeThreshold(_threshold);
@@ -139,7 +139,7 @@ abstract contract OwnerManager is SelfAuthorized, IOwnerManager {
         while (currentOwner != SENTINEL_OWNERS) {
             array[index] = currentOwner;
             currentOwner = owners[currentOwner];
-            index++;
+            ++index;
         }
         return array;
     }

--- a/contracts/common/StorageAccessible.sol
+++ b/contracts/common/StorageAccessible.sol
@@ -16,7 +16,7 @@ abstract contract StorageAccessible {
      */
     function getStorageAt(uint256 offset, uint256 length) public view returns (bytes memory) {
         bytes memory result = new bytes(length * 32);
-        for (uint256 index = 0; index < length; index++) {
+        for (uint256 index = 0; index < length; ++index) {
             /* solhint-disable no-inline-assembly */
             /// @solidity memory-safe-assembly
             assembly {

--- a/contracts/handler/extensible/ERC165Handler.sol
+++ b/contracts/handler/extensible/ERC165Handler.sol
@@ -53,7 +53,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
     function addSupportedInterfaceBatch(bytes4 _interfaceId, bytes32[] calldata handlerWithSelectors) external override onlySelf {
         ISafe safe = ISafe(payable(_msgSender()));
         bytes4 interfaceId;
-        for (uint256 i = 0; i < handlerWithSelectors.length; i++) {
+        for (uint256 i = 0; i < handlerWithSelectors.length; ++i) {
             (bool isStatic, bytes4 selector, address handlerAddress) = MarshalLib.decodeWithSelector(handlerWithSelectors[i]);
             _setSafeMethod(safe, selector, MarshalLib.encode(isStatic, handlerAddress));
             if (i > 0) {
@@ -75,7 +75,7 @@ abstract contract ERC165Handler is ExtensibleBase, IERC165Handler {
     function removeSupportedInterfaceBatch(bytes4 _interfaceId, bytes4[] calldata selectors) external override onlySelf {
         ISafe safe = ISafe(payable(_msgSender()));
         bytes4 interfaceId;
-        for (uint256 i = 0; i < selectors.length; i++) {
+        for (uint256 i = 0; i < selectors.length; ++i) {
             _setSafeMethod(safe, selectors[i], bytes32(0));
             if (i > 0) {
                 interfaceId ^= selectors[i];

--- a/contracts/libraries/SafeToL2Migration.sol
+++ b/contracts/libraries/SafeToL2Migration.sol
@@ -185,7 +185,7 @@ contract SafeToL2Migration is SafeStorage {
         while (currentOwner != sentinelOwners) {
             array[index] = currentOwner;
             currentOwner = owners[currentOwner];
-            index++;
+            ++index;
         }
         return array;
     }


### PR DESCRIPTION
This pull request includes several changes to increment and decrement operations in various Solidity contract files. The primary goal is to decrease gas usage.

Pre-increments and pre-decrements are cheaper.
For a uint256 i variable, the following is true with the Optimizer enabled at 10k:
Increment:
- i += 1 is the most expensive form
- i++ costs 6 gas less than i += 1
- ++i costs 5 gas less than i++ (11 gas less than i += 1)

Decrement:
- i -= 1 is the most expensive form
- i-- costs 11 gas less than i -= 1
- --i costs 5 gas less than i-- (16 gas less than i -= 1)

Changes to increment and decrement operations:

* [`contracts/Safe.sol`](diffhunk://#diff-587b494ea631bb6b7adf4fc3e1a2e6a277a385ff16e1163b26e39de24e9483deL296-R296): Updated the for loop to use the prefix increment operator in the `Safe` contract.
* [`contracts/base/ModuleManager.sol`](diffhunk://#diff-82762908b9416ddadffb149ee4d25f328078fc27f938d454d8a207aad1ec3839L215-R215): Changed the increment operation to use the prefix increment operator in the `ModuleManager` contract.
* [`contracts/base/OwnerManager.sol`](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L38-R38): Multiple updates to use prefix increment and decrement operators in the `OwnerManager` contract. [[1]](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L38-R38) [[2]](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L63-R63) [[3]](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L80-R80) [[4]](diffhunk://#diff-795fb06764b4c2d991707584a31509badf0b036c9401bfbcb82d6bc9fdebab82L142-R142)
* [`contracts/common/StorageAccessible.sol`](diffhunk://#diff-a7dd65d90b0567bb9ba14ecd4ff414529a934cd3752ccf309800fad93fba354eL19-R19): Modified the for loop to use the prefix increment operator in the `StorageAccessible` contract.
* [`contracts/handler/extensible/ERC165Handler.sol`](diffhunk://#diff-aa0838f20fd3f37b00dc661645b4641500e68762b9b624addb99465fcc65a3e0L56-R56): Updated for loops to use the prefix increment operator in the `ERC165Handler` contract. [[1]](diffhunk://#diff-aa0838f20fd3f37b00dc661645b4641500e68762b9b624addb99465fcc65a3e0L56-R56) [[2]](diffhunk://#diff-aa0838f20fd3f37b00dc661645b4641500e68762b9b624addb99465fcc65a3e0L78-R78)
* [`contracts/libraries/SafeToL2Migration.sol`](diffhunk://#diff-925588b812f729cc164d14a48e571ce813e2f0ae6f5c5420fc0382c767287fd0L188-R188): Changed the increment operation to use the prefix increment operator in the `SafeToL2Migration` contract.