### PR TITLE
chore: fix typo in certora/specs/OwnerReach.spec

### DIFF
--- a/certora/specs/OwnerReach.spec
+++ b/certora/specs/OwnerReach.spec
@@ -289,7 +289,7 @@ rule isOwnerDoesNotRevert {
     assert !lastReverted, "isOwner should not revert";
 }
 
-rule isOwnerNotSelfOrSentinal {
+rule isOwnerNotSelfOrSentinel {
     address addr;
     require addr == currentContract || addr == SENTINEL;
     requireInvariant self_not_owner();


### PR DESCRIPTION
Hello, I found a typo error in `certora/specs/OwnerReach.spec`: 

`isOwnerNotSelfOrSentinal ` -> `isOwnerNotSelfOrSentinel`

Thank you.