### PR TITLE
Check MultiCallSendOnly Leftover Balance

### DIFF
--- a/contracts/libraries/MultiSendCallOnly.sol
+++ b/contracts/libraries/MultiSendCallOnly.sol
@@ -9,6 +9,15 @@ pragma solidity >=0.7.0 <0.9.0;
  */
 contract MultiSendCallOnly {
     /**
+     * @dev The address of the {MultiSendCallOnly} contract.
+     */
+    address private immutable MULTISEND_SINGLETON;
+
+    constructor() {
+        MULTISEND_SINGLETON = address(this);
+    }
+
+    /**
      * @dev Sends multiple transactions and reverts all if one fails.
      * @param transactions Encoded transactions. Each transaction is encoded as a packed bytes of
      *                     operation has to be uint8(0) in this version (=> 1 byte),
@@ -67,5 +76,7 @@ contract MultiSendCallOnly {
             }
         }
         /* solhint-enable no-inline-assembly */
+
+        require(address(this) != MULTISEND_SINGLETON || address(this).balance == 0, "MultiSend has leftover balance");
     }
 }


### PR DESCRIPTION
This PR proposes a change to the `MultiCallSendOnly` contract such that, when not `DELEGATECALL`ed, it ensures that value of the call matches the total value of the inner meta-transactions. This prevents accidentally sending more value to the `multiSend` that is being used for the meta-transactions and having some bot take the extra Eth before you can recover it.

Note that this is implemented by doing accounting on the `value` of each meta-transaction, since using `address(this).balance` is not a good idea (it would allow anyone to front-run a `multiSend` `CALL` transaction and cause it to revert).

I'm not convinced that this is a good idea, so I am leaving this in "draft" for now.